### PR TITLE
GUAC-1511: Fix audio input bugs in initial client implementation.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
@@ -71,13 +71,13 @@ Guacamole.ArrayBufferWriter = function(stream) {
         var bytes = new Uint8Array(data);
 
         // If small enough to fit into single instruction, send as-is
-        if (bytes.length <= 8064)
+        if (bytes.length <= 6048)
             __send_blob(bytes);
 
         // Otherwise, send as multiple instructions
         else {
-            for (var offset=0; offset<bytes.length; offset += 8064)
-                __send_blob(bytes.subarray(offset, offset + 8094));
+            for (var offset=0; offset<bytes.length; offset += 6048)
+                __send_blob(bytes.subarray(offset, offset + 6048));
         }
 
     };

--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -115,6 +115,18 @@ Guacamole.AudioRecorder.getInstance = function getInstance(stream, mimetype) {
 Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
 
     /**
+     * The size of audio buffer to request from the Web Audio API when
+     * recording or processing audio, in sample-frames. This must be a power of
+     * two between 256 and 16384 inclusive, as required by
+     * AudioContext.createScriptProcessor().
+     *
+     * @private
+     * @constant
+     * @type {Number}
+     */
+    var BUFFER_SIZE = 512;
+
+    /**
      * The format of audio this recorder will encode.
      *
      * @private
@@ -172,16 +184,6 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
     var maxSampleValue = (format.bytesPerSample === 1) ? 128 : 32768;
 
     /**
-     * The size of audio buffer to request from the Web Audio API when
-     * recording audio. This must be a power of two between 256 and 16384
-     * inclusive, as required by AudioContext.createScriptProcessor().
-     *
-     * @private
-     * @type {Number}
-     */
-    var bufferSize = format.bytesPerSample * 256;
-
-    /**
      * Converts the given AudioBuffer into an audio packet, ready for streaming
      * along the underlying output stream. Unlike the raw audio packets used by
      * this audio recorder, AudioBuffers require floating point samples and are
@@ -232,7 +234,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
         getUserMedia({ 'audio' : true }, function streamReceived(mediaStream) {
 
             // Create processing node which receives appropriately-sized audio buffers
-            var processor = context.createScriptProcessor(bufferSize, format.channels, format.channels);
+            var processor = context.createScriptProcessor(BUFFER_SIZE, format.channels, format.channels);
             processor.connect(context.destination);
 
             // Send blobs when audio buffers are received

--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -237,7 +237,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
 
             // Send blobs when audio buffers are received
             processor.onaudioprocess = function processAudio(e) {
-                writer.sendData(toSampleArray(e.inputBuffer));
+                writer.sendData(toSampleArray(e.inputBuffer).buffer);
             };
 
             // Connect processing node to user's audio input source

--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -199,7 +199,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
     var toSampleArray = function toSampleArray(audioBuffer) {
 
         // Get array for raw PCM storage
-        var data = new SampleArray(audioBuffer.length);
+        var data = new SampleArray(audioBuffer.length * format.channels);
 
         // Convert each channel
         for (var channel = 0; channel < format.channels; channel++) {

--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -179,7 +179,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
      * @private
      * @type {Number}
      */
-    var bufferSize = format.bytesPerSample * 4096;
+    var bufferSize = format.bytesPerSample * 256;
 
     /**
      * Converts the given AudioBuffer into an audio packet, ready for streaming

--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -200,8 +200,12 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
      */
     var toSampleArray = function toSampleArray(audioBuffer) {
 
+        // Calculate the number of samples in both input and output
+        var inSamples = audioBuffer.length;
+        var outSamples = Math.floor(audioBuffer.duration * format.rate);
+
         // Get array for raw PCM storage
-        var data = new SampleArray(audioBuffer.length * format.channels);
+        var data = new SampleArray(outSamples * format.channels);
 
         // Convert each channel
         for (var channel = 0; channel < format.channels; channel++) {
@@ -210,9 +214,14 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
 
             // Fill array with data from audio buffer channel
             var offset = channel;
-            for (var i = 0; i < audioData.length; i++) {
-                data[offset] = audioData[i] * maxSampleValue;
+            for (var i = 0; i < outSamples; i++) {
+
+                // Apply naiive resampling
+                var inOffset = Math.floor(i / outSamples * inSamples);
+                data[offset] = Math.floor(audioData[inOffset] * maxSampleValue);
+
                 offset += format.channels;
+
             }
 
         }


### PR DESCRIPTION
This change addresses the following issues discovered during continued development of GUAC-1511:

1. The blob size used by `Guacamole.ArrayBufferWriter` was too large, and could easily exceed the per-instruction maximum of 8192 bytes enforced by guacd.
2. The buffer size used by `Guacamole.RawAudioRecorder` is actually in sample-frames, not in bytes. There is no need to increase the buffer size with respect to the number of bytes per sample.
3. The `SampleArray` is not in sample-frames, but in samples. Its size must take the number of channels into account.
4. There is no guarantee that the browser will magically use the sample rate desired. We need resample as necessary to force the audio to the correct format. I've added rather naiive, simple resampling. We should look into a better algorithm that is less prone to aliasing.