### PR TITLE
GUACAMOLE-25: Address quality issues with audio input

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -124,7 +124,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
      * @constant
      * @type {Number}
      */
-    var BUFFER_SIZE = 512;
+    var BUFFER_SIZE = 2048;
 
     /**
      * The window size to use when applying Lanczos interpolation, commonly


### PR DESCRIPTION
This change fixes issues in recorded audio quality due to:

1. Overly-naive resampling
2. Underflow/overflow due to rounding error (again related to resampling)
3. Insufficient buffering

Lacking these improvements, recorded audio is full of clicks and gradually falls out of sync.