### PR TITLE
GUACAMOLE-25: Add "enable-audio-input" parameter for RDP.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -124,6 +124,11 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "enable-audio-input",
+                    "type"    : "BOOLEAN",
+                    "options" : [ "true" ]
+                },
+                {
                     "name"    : "enable-printing",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -280,6 +280,7 @@
         "FIELD_HEADER_DOMAIN"          : "Domain:",
         "FIELD_HEADER_DPI"             : "Resolution (DPI):",
         "FIELD_HEADER_DRIVE_PATH"      : "Drive path:",
+        "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Enable audio input (microphone):",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Enable desktop composition (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Enable drive:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Enable font smoothing (ClearType):",


### PR DESCRIPTION
The significantly-simpler sibling of apache/incubator-guacamole-server#12.