### PR TITLE
GUACAMOLE-44: Slice uploaded files into chunks (DO NOT slurp entire file into memory)

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
@@ -62,6 +62,20 @@ Guacamole.ArrayBufferWriter = function(stream) {
     }
 
     /**
+     * The maximum length of any blob sent by this Guacamole.ArrayBufferWriter,
+     * in bytes. Data sent via
+     * {@link Guacamole.ArrayBufferWriter#sendData|sendData()} which exceeds
+     * this length will be split into multiple blobs. As the Guacamole protocol
+     * limits the maximum size of any instruction or instruction element to
+     * 8192 bytes, and the contents of blobs will be base64-encoded, this value
+     * should only be increased with extreme caution.
+     *
+     * @type {Number}
+     * @default {@link Guacamole.ArrayBufferWriter.DEFAULT_BLOB_LENGTH}
+     */
+    this.blobLength = Guacamole.ArrayBufferWriter.DEFAULT_BLOB_LENGTH;
+
+    /**
      * Sends the given data.
      * 
      * @param {ArrayBuffer|TypedArray} data The data to send.
@@ -71,13 +85,13 @@ Guacamole.ArrayBufferWriter = function(stream) {
         var bytes = new Uint8Array(data);
 
         // If small enough to fit into single instruction, send as-is
-        if (bytes.length <= 6048)
+        if (bytes.length <= guac_writer.blobLength)
             __send_blob(bytes);
 
         // Otherwise, send as multiple instructions
         else {
-            for (var offset=0; offset<bytes.length; offset += 6048)
-                __send_blob(bytes.subarray(offset, offset + 6048));
+            for (var offset=0; offset<bytes.length; offset += guac_writer.blobLength)
+                __send_blob(bytes.subarray(offset, offset + guac_writer.blobLength));
         }
 
     };
@@ -98,3 +112,12 @@ Guacamole.ArrayBufferWriter = function(stream) {
     this.onack = null;
 
 };
+
+/**
+ * The default maximum blob length for new Guacamole.ArrayBufferWriter
+ * instances.
+ *
+ * @constant
+ * @type {Number}
+ */
+Guacamole.ArrayBufferWriter.DEFAULT_BLOB_LENGTH = 6048;

--- a/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/ArrayBufferWriter.js
@@ -64,7 +64,7 @@ Guacamole.ArrayBufferWriter = function(stream) {
     /**
      * The maximum length of any blob sent by this Guacamole.ArrayBufferWriter,
      * in bytes. Data sent via
-     * {@link Guacamole.ArrayBufferWriter#sendData|sendData()} which exceeds
+     * [sendData()]{@link Guacamole.ArrayBufferWriter#sendData} which exceeds
      * this length will be split into multiple blobs. As the Guacamole protocol
      * limits the maximum size of any instruction or instruction element to
      * 8192 bytes, and the contents of blobs will be base64-encoded, this value

--- a/guacamole-common-js/src/main/webapp/modules/FileWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/FileWriter.js
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Guacamole = Guacamole || {};
+
+/**
+ * A writer which automatically writes to the given output stream with the
+ * contents of a local files, supplied as standard File objects.
+ *
+ * @constructor
+ * @param {Guacamole.OutputStream} stream
+ *     The stream that data will be written to.
+ */
+Guacamole.FileWriter = function FileWriter(stream) {
+
+    /**
+     * Reference to this Guacamole.FileWriter.
+     *
+     * @private
+     * @type {Guacamole.FileWriter}
+     */
+    var guacWriter = this;
+
+    /**
+     * Wrapped Guacamole.ArrayBufferWriter which will be used to send any
+     * provided file data.
+     *
+     * @private
+     * @type {Guacamole.ArrayBufferWriter}
+     */
+    var arrayBufferWriter = new Guacamole.ArrayBufferWriter(stream);
+
+    // Initially, simply call onack for acknowledgements
+    arrayBufferWriter.onack = function(status) {
+        if (guacWriter.onack)
+            guacWriter.onack(status);
+    };
+
+    /**
+     * Browser-independent implementation of Blob.slice() which uses an end
+     * offset to determine the span of the resulting slice, rather than a
+     * length.
+     *
+     * @private
+     * @param {Blob} blob
+     *     The Blob to slice.
+     *
+     * @param {Number} start
+     *     The starting offset of the slice, in bytes, inclusive.
+     *
+     * @param {Number} end
+     *     The ending offset of the slice, in bytes, exclusive.
+     *
+     * @returns {Blob}
+     *     A Blob containing the data within the given Blob starting at
+     *     <code>start</code> and ending at <code>end - 1</code>.
+     */
+    var slice = function slice(blob, start, end) {
+
+        // Use prefixed implementations if necessary
+        var sliceImplementation = (
+                blob.slice
+             || blob.webkitSlice
+             || blob.mozSlice
+        ).bind(blob);
+
+        var length = end - start;
+
+        // The old Blob.slice() was length-based (not end-based). Try the
+        // length version first, if the two calls are not equivalent.
+        if (length !== end) {
+
+            // If the result of the slice() call matches the expected length,
+            // trust that result. It must be correct.
+            var sliceResult = sliceImplementation(start, length);
+            if (sliceResult.size === length)
+                return sliceResult;
+
+        }
+
+        // Otherwise, use the most-recent standard: end-based slice()
+        return sliceImplementation(start, end);
+
+    };
+
+    /**
+     * Sends the contents of the given file over the underlying stream.
+     *
+     * @param {File} file
+     *     The file to send.
+     */
+    this.sendFile = function sendFile(file) {
+
+        var offset = 0;
+        var reader = new FileReader();
+
+        /**
+         * Reads the next chunk of the file provided to
+         * {@link Guacamole.FileWriter#sendFile|sendFile()}. The chunk itself
+         * is read asynchronously, and will not be available until
+         * reader.onload fires.
+         *
+         * @private
+         */
+        var readNextChunk = function readNextChunk() {
+
+            // If no further chunks remain, inform of completion and stop
+            if (offset >= file.size) {
+
+                // Fire completion event for completed file
+                if (guacWriter.oncomplete)
+                    guacWriter.oncomplete(file);
+
+                // No further chunks to read
+                return;
+
+            }
+
+            // Obtain reference to next chunk as a new blob
+            var chunk = slice(file, offset, offset + arrayBufferWriter.blobLength);
+            offset += arrayBufferWriter.blobLength;
+
+            // Attempt to read the file contents represented by the blob into
+            // a new array buffer
+            reader.readAsArrayBuffer(chunk);
+
+        };
+
+        // Send each chunk over the stream, continue reading the next chunk
+        reader.onload = function chunkLoadComplete() {
+
+            // Send the successfully-read chunk
+            arrayBufferWriter.sendData(reader.result);
+
+            // Continue sending more chunks after the latest chunk is
+            // acknowledged
+            arrayBufferWriter.onack = function sendMoreChunks(status) {
+
+                if (guacWriter.onack)
+                    guacWriter.onack(status);
+
+                // Abort transfer if an error occurs
+                if (status.isError())
+                    return;
+
+                // Inform of file upload progress via progress events
+                if (guacWriter.onprogress)
+                    guacWriter.onprogress(file, offset - arrayBufferWriter.blobLength);
+
+                // Queue the next chunk for reading
+                readNextChunk();
+
+            };
+
+        };
+
+        // If an error prevents further reading, inform of error and stop
+        reader.onerror = function chunkLoadFailed() {
+
+            // Fire error event, including the context of the error
+            if (guacWriter.onerror)
+                guacWriter.onerror(file, offset, reader.error);
+
+        };
+
+        // Begin reading the first chunk
+        readNextChunk();
+
+    };
+
+    /**
+     * Signals that no further text will be sent, effectively closing the
+     * stream.
+     */
+    this.sendEnd = function sendEnd() {
+        arrayBufferWriter.sendEnd();
+    };
+
+    /**
+     * Fired for received data, if acknowledged by the server.
+     *
+     * @event
+     * @param {Guacamole.Status} status
+     *     The status of the operation.
+     */
+    this.onack = null;
+
+    /**
+     * Fired when an error occurs reading a file passed to
+     * {@link Guacamole.FileWriter#sendFile|sendFile()}. The file transfer for
+     * the given file will cease, but the stream will remain open.
+     *
+     * @event
+     * @param {File} file
+     *     The file that was being read when the error occurred.
+     *
+     * @param {Number} offset
+     *     The offset of the failed read attempt within the file, in bytes.
+     *
+     * @param {DOMError} error
+     *     The error that occurred.
+     */
+    this.onerror = null;
+
+    /**
+     * Fired for each successfully-read chunk of file data as a file is being
+     * sent via {@link Guacamole.FileWriter#sendFile|sendFile()}.
+     *
+     * @event
+     * @param {File} file
+     *     The file that is being read.
+     *
+     * @param {Number} offset
+     *     The offset of the read that just succeeded.
+     */
+    this.onprogress = null;
+
+    /**
+     * Fired when a file passed to
+     * {@link Guacamole.FileWriter#sendFile|sendFile()} has finished being sent.
+     *
+     * @event
+     * @param {File} file
+     *     The file that was sent.
+     */
+    this.oncomplete = null;
+
+};

--- a/guacamole-common-js/src/main/webapp/modules/FileWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/FileWriter.js
@@ -112,7 +112,7 @@ Guacamole.FileWriter = function FileWriter(stream) {
 
         /**
          * Reads the next chunk of the file provided to
-         * {@link Guacamole.FileWriter#sendFile|sendFile()}. The chunk itself
+         * [sendFile()]{@link Guacamole.FileWriter#sendFile}. The chunk itself
          * is read asynchronously, and will not be available until
          * reader.onload fires.
          *
@@ -203,7 +203,7 @@ Guacamole.FileWriter = function FileWriter(stream) {
 
     /**
      * Fired when an error occurs reading a file passed to
-     * {@link Guacamole.FileWriter#sendFile|sendFile()}. The file transfer for
+     * [sendFile()]{@link Guacamole.FileWriter#sendFile}. The file transfer for
      * the given file will cease, but the stream will remain open.
      *
      * @event
@@ -220,7 +220,7 @@ Guacamole.FileWriter = function FileWriter(stream) {
 
     /**
      * Fired for each successfully-read chunk of file data as a file is being
-     * sent via {@link Guacamole.FileWriter#sendFile|sendFile()}.
+     * sent via [sendFile()]{@link Guacamole.FileWriter#sendFile}.
      *
      * @event
      * @param {File} file
@@ -233,7 +233,8 @@ Guacamole.FileWriter = function FileWriter(stream) {
 
     /**
      * Fired when a file passed to
-     * {@link Guacamole.FileWriter#sendFile|sendFile()} has finished being sent.
+     * [sendFile()]{@link Guacamole.FileWriter#sendFile} has finished being
+     * sent.
      *
      * @event
      * @param {File} file


### PR DESCRIPTION
The old file upload code was inherently flawed as it required reading the entire file into memory. Besides being a poor user experience (long delay before upload begins), this could even crash the browser if the file was large enough.

This change adds a new writer-style object, `Guacamole.FileWriter`, whose `sendFile()` efficiently streams a provided `File` over an underlying `Guacamole.OutputStream`. The implementation streams the `File` properly via `slice()`; it is not read in its entirety into memory.

As this required wrapping a `Guacamole.ArrayBufferWriter` and being aware of the Guacamole protocol's instruction size restrictions, this change replaces the old magic 6048 with a well-documented constant, `Guacamole.ArrayBufferWriter.DEFAULT_BLOB_LENGTH`, and exposes the blob length used by any particular `Guacamole.ArrayBufferWriter` instance with a mutable `blobLength` property.