### PR TITLE
GUACAMOLE-44: ManagedFileUpload.getInstance() must not directly invoke $apply()

### DIFF
--- a/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
@@ -139,7 +139,7 @@ angular.module('client').factory('ManagedFileUpload', ['$rootScope', '$injector'
             stream = object.createOutputStream(file.type, streamName);
 
         // Notify that the file transfer is pending
-        $rootScope.$apply(function uploadStreamOpen() {
+        $rootScope.$evalAsync(function uploadStreamOpen() {
 
             // Init managed upload
             managedFileUpload.filename = file.name;


### PR DESCRIPTION
As `ManagedFileUpload.getInstance()` is sometimes invoked within `$apply()`, invoking `$apply()` again directly results in a `$digest` loop and error.