### PR TITLE
GUACAMOLE-44: Implement uploads within tunnel REST endpoint

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleStatus.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleStatus.java
@@ -166,5 +166,31 @@ public enum GuacamoleStatus {
     public int getGuacamoleStatusCode() {
         return guac_code;
     }
-    
+
+    /**
+     * Returns the GuacamoleStatus corresponding to the given Guacamole
+     * protocol status code. If no such GuacamoleStatus is defined, null is
+     * returned.
+     *
+     * @param code
+     *     The Guacamole protocol status code to translate into a
+     *     GuacamoleStatus.
+     *
+     * @return
+     *     The GuacamoleStatus corresponding to the given Guacamole protocol
+     *     status code, or null if no such GuacamoleStatus is defined.
+     */
+    public static GuacamoleStatus fromGuacamoleStatusCode(int code) {
+
+        // Search for a GuacamoleStatus having the given status code
+        for (GuacamoleStatus status : values()) {
+            if (status.getGuacamoleStatusCode() == code)
+                return status;
+        }
+
+        // No such status found
+        return null;
+
+    }
+
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIError.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIError.java
@@ -37,6 +37,11 @@ public class APIError {
     private final String message;
 
     /**
+     * The associated Guacamole protocol status code.
+     */
+    private final Integer statusCode;
+
+    /**
      * All expected request parameters, if any, as a collection of fields.
      */
     private final Collection<Field> expected;
@@ -81,7 +86,14 @@ public class APIError {
         /**
          * Permission was denied to perform the requested operation.
          */
-        PERMISSION_DENIED(Response.Status.FORBIDDEN);
+        PERMISSION_DENIED(Response.Status.FORBIDDEN),
+
+        /**
+         * An error occurred within an intercepted stream, terminating that
+         * stream. The Guacamole protocol status code of that error can be
+         * retrieved with getStatusCode().
+         */
+        STREAM_ERROR(Response.Status.BAD_REQUEST);
 
         /**
          * The HTTP status associated with this error type.
@@ -111,6 +123,27 @@ public class APIError {
     }
 
     /**
+     * Creates a new APIError of type STREAM_ERROR and having the given
+     * Guacamole protocol status code and human-readable message. The status
+     * code and message should be taken directly from the "ack" instruction
+     * causing the error.
+     *
+     * @param statusCode
+     *     The Guacamole protocol status code describing the error that
+     *     occurred within the intercepted stream.
+     *
+     * @param message
+     *     An arbitrary human-readable message describing the error that
+     *     occurred.
+     */
+    public APIError(int statusCode, String message) {
+        this.type       = Type.STREAM_ERROR;
+        this.message    = message;
+        this.statusCode = statusCode;
+        this.expected   = null;
+    }
+
+    /**
      * Create a new APIError with the specified error message.
      *
      * @param type
@@ -120,9 +153,10 @@ public class APIError {
      *     The error message.
      */
     public APIError(Type type, String message) {
-        this.type     = type;
-        this.message  = message;
-        this.expected = null;
+        this.type       = type;
+        this.message    = message;
+        this.statusCode = null;
+        this.expected   = null;
     }
 
     /**
@@ -140,9 +174,10 @@ public class APIError {
      *     a result of the original request, as a collection of fields.
      */
     public APIError(Type type, String message, Collection<Field> expected) {
-        this.type     = type;
-        this.message  = message;
-        this.expected = expected;
+        this.type       = type;
+        this.message    = message;
+        this.statusCode = null;
+        this.expected   = expected;
     }
 
     /**
@@ -153,6 +188,19 @@ public class APIError {
      */
     public Type getType() {
         return type;
+    }
+
+    /**
+     * Returns the Guacamole protocol status code associated with the error
+     * that occurred. This is only valid for errors of type STREAM_ERROR.
+     *
+     * @return
+     *     The Guacamole protocol status code associated with the error that
+     *     occurred. If the error is not of type STREAM_ERROR, this will be
+     *     null.
+     */
+    public Integer getStatusCode() {
+        return statusCode;
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIException.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIException.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.apache.guacamole.form.Field;
+import org.apache.guacamole.protocol.GuacamoleStatus;
 
 /**
  * An exception that will result in the given error error information being
@@ -58,6 +59,43 @@ public class APIException extends WebApplicationException {
      */
     public APIException(APIError.Type type, String message) {
         this(new APIError(type, message));
+    }
+
+    /**
+     * Creates a new APIException which represents an error that occurred within
+     * an intercepted Guacamole stream. The nature of that error will be
+     * described by a given status code, which should be the status code
+     * provided by the "ack" instruction that reported the error.
+     *
+     * @param status
+     *     The Guacamole protocol status code describing the error that
+     *     occurred within the intercepted stream.
+     *
+     * @param message
+     *     An arbitrary human-readable message describing the error that
+     *     occurred.
+     */
+    public APIException(int status, String message) {
+        this(new APIError(status, message));
+    }
+
+    /**
+     * Creates a new APIException which represents an error that occurred within
+     * an intercepted Guacamole stream. The nature of that error will be
+     * described by a given Guacamole protocol status, which should be the
+     * status associated with the code provided by the "ack" instruction that
+     * reported the error.
+     *
+     * @param status
+     *     The Guacamole protocol status describing the error that occurred
+     *     within the intercepted stream.
+     *
+     * @param message
+     *     An arbitrary human-readable message describing the error that
+     *     occurred.
+     */
+    public APIException(GuacamoleStatus status, String message) {
+        this(status.getGuacamoleStatusCode(), message);
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
@@ -34,6 +34,7 @@ import org.apache.guacamole.GuacamoleUnauthorizedException;
 import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
 import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
 import org.apache.guacamole.rest.auth.AuthenticationService;
+import org.apache.guacamole.tunnel.GuacamoleStreamException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -243,6 +244,21 @@ public class RESTExceptionWrapper implements MethodInterceptor {
 
             throw new APIException(
                 APIError.Type.BAD_REQUEST,
+                message
+            );
+
+        }
+
+        // Errors from intercepted streams
+        catch (GuacamoleStreamException e) {
+
+            // Generate default message
+            String message = e.getMessage();
+            if (message == null)
+                message = "Error reported by stream.";
+
+            throw new APIException(
+                e.getStatus(),
                 message
             );
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelRESTService.java
@@ -136,7 +136,12 @@ public class TunnelRESTService {
 
             @Override
             public void write(OutputStream output) throws IOException {
-                tunnel.interceptStream(streamIndex, output);
+                try {
+                    tunnel.interceptStream(streamIndex, output);
+                }
+                catch (GuacamoleException e) {
+                    throw new IOException(e);
+                }
             }
 
         };
@@ -167,8 +172,9 @@ public class TunnelRESTService {
      *     stream.
      *
      * @throws GuacamoleException
-     *     If the session associated with the given auth token cannot be
-     *     retrieved, or if no such tunnel exists.
+     *     If the session associated with the given auth
+     *     token cannot be retrieved, if no such tunnel exists, or if the
+     *     intercepted stream itself closes with an error.
      */
     @POST
     @Consumes(MediaType.WILDCARD)

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelRESTService.java
@@ -172,9 +172,9 @@ public class TunnelRESTService {
      *     stream.
      *
      * @throws GuacamoleException
-     *     If the session associated with the given auth
-     *     token cannot be retrieved, if no such tunnel exists, or if the
-     *     intercepted stream itself closes with an error.
+     *     If the session associated with the given auth token cannot be
+     *     retrieved, if no such tunnel exists, or if the intercepted stream
+     *     itself closes with an error.
      */
     @POST
     @Consumes(MediaType.WILDCARD)

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/GuacamoleStreamException.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/GuacamoleStreamException.java
@@ -46,7 +46,7 @@ public class GuacamoleStreamException extends GuacamoleServerException {
      *
      * @param message
      *     The human readable description of the error that occurred, as
-     *     as provided by the stream.
+     *     provided by the stream.
      */
     public GuacamoleStreamException(GuacamoleStatus status, String message) {
         super(message);

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/GuacamoleStreamException.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/GuacamoleStreamException.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * A generic exception thrown when an intercepted Guacamole stream has closed
+ * with an error condition. Guacamole streams report errors using the "ack"
+ * instruction, which provides a status code and human-readable message.
+ *
+ * @author Michael Jumper
+ */
+public class GuacamoleStreamException extends GuacamoleServerException {
+
+    /**
+     * The error condition reported by the intercepted Guacamole stream.
+     */
+    private final GuacamoleStatus status;
+
+    /**
+     * Creates a new GuacamoleStreamException representing an error returned by
+     * an intercepted stream.
+     *
+     * @param status
+     *     The status code of the error condition reported by the intercepted
+     *     Guacamole stream.
+     *
+     * @param message
+     *     The human readable description of the error that occurred, as
+     *     as provided by the stream.
+     */
+    public GuacamoleStreamException(GuacamoleStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return status;
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/InputStreamInterceptingFilter.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/InputStreamInterceptingFilter.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import javax.xml.bind.DatatypeConverter;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.protocol.GuacamoleInstruction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter which selectively intercepts "ack" instructions, automatically reading
+ * from or closing the stream given with interceptStream(). The required "blob"
+ * and "end" instructions denoting the content and boundary of the stream are
+ * sent automatically.
+ */
+public class InputStreamInterceptingFilter
+        extends StreamInterceptingFilter<InputStream> {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger =
+            LoggerFactory.getLogger(InputStreamInterceptingFilter.class);
+
+    /**
+     * Creates a new InputStreamInterceptingFilter which selectively intercepts
+     * "ack" instructions. The required "blob" and "end" instructions will
+     * automatically be sent over the given tunnel based on the content of
+     * provided InputStreams.
+     *
+     * @param tunnel
+     *     The GuacamoleTunnel over which any required "blob" and "end"
+     *     instructions should be sent.
+     */
+    public InputStreamInterceptingFilter(GuacamoleTunnel tunnel) {
+        super(tunnel);
+    }
+
+    /**
+     * Injects a "blob" instruction into the outbound Guacamole protocol
+     * stream, as if sent by the connected client. "blob" instructions are used
+     * to send chunks of data along a stream.
+     *
+     * @param index
+     *     The index of the stream that this "blob" instruction relates to.
+     *
+     * @param blob
+     *     The chunk of data to send within the "blob" instruction.
+     */
+    private void sendBlob(String index, byte[] blob) {
+
+        // Send "blob" containing provided data
+        sendInstruction(new GuacamoleInstruction("blob", index,
+            DatatypeConverter.printBase64Binary(blob)));
+
+    }
+
+    /**
+     * Injects an "end" instruction into the outbound Guacamole protocol
+     * stream, as if sent by the connected client. "end" instructions are used
+     * to signal the end of a stream.
+     *
+     * @param index
+     *     The index of the stream that this "end" instruction relates to.
+     */
+    private void sendEnd(String index) {
+        sendInstruction(new GuacamoleInstruction("end", index));
+    }
+
+    /**
+     * Reads the next chunk of data from the InputStream associated with an
+     * intercepted stream, sending that data as a "blob" instruction over the
+     * GuacamoleTunnel associated with this filter. If the end of the
+     * InputStream is reached, an "end" instruction will automatically be sent.
+     *
+     * @param stream
+     *     The stream from which the next chunk of data should be read.
+     */
+    private void readNextBlob(InterceptedStream<InputStream> stream) {
+
+        // Read blob from stream if it exists
+        try {
+
+            // Read raw data from input stream
+            byte[] blob = new byte[6048];
+            int length = stream.getStream().read(blob);
+
+            // End stream if no more data
+            if (length == -1) {
+
+                // Close stream, send end if the stream is still valid
+                if (closeInterceptedStream(stream))
+                    sendEnd(stream.getIndex());
+
+                return;
+
+            }
+
+            // Inject corresponding "blob" instruction
+            sendBlob(stream.getIndex(), Arrays.copyOf(blob, length));
+
+        }
+
+        // Terminate stream if it cannot be read
+        catch (IOException e) {
+
+            logger.debug("Unable to read data of intercepted input stream.", e);
+
+            // Close stream, send end if the stream is still valid
+            if (closeInterceptedStream(stream))
+                sendEnd(stream.getIndex());
+
+        }
+
+    }
+
+    /**
+     * Handles a single "ack" instruction, sending yet more blobs or closing the
+     * stream depending on whether the "ack" indicates success or failure. If no
+     * InputStream is associated with the stream index within the "ack"
+     * instruction, the instruction is ignored.
+     *
+     * @param instruction
+     *     The "ack" instruction being handled.
+     */
+    private void handleAck(GuacamoleInstruction instruction) {
+
+        // Verify all required arguments are present
+        List<String> args = instruction.getArgs();
+        if (args.size() < 3)
+            return;
+
+        // Pull associated stream
+        String index = args.get(0);
+        InterceptedStream<InputStream> stream = getInterceptedStream(index);
+        if (stream == null)
+            return;
+
+        // Pull status code
+        String status = args.get(2);
+
+        // Terminate stream if an error is encountered
+        if (!status.equals("0")) {
+            closeInterceptedStream(stream);
+            return;
+        }
+
+        // Send next blob
+        readNextBlob(stream);
+
+    }
+
+    @Override
+    public GuacamoleInstruction filter(GuacamoleInstruction instruction)
+            throws GuacamoleException {
+
+        // Intercept "ack" instructions for in-progress streams
+        if (instruction.getOpcode().equals("ack"))
+            handleAck(instruction);
+
+        // Pass instruction through untouched
+        return instruction;
+
+    }
+
+    @Override
+    protected void handleInterceptedStream(InterceptedStream<InputStream> stream) {
+
+        // Read the first blob. Note that future blobs will be read in response
+        // to received "ack" instructions.
+        readNextBlob(stream);
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStream.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStream.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import java.io.Closeable;
+
+/**
+ * A simple pairing of the index of an intercepted Guacamole stream with the
+ * stream-type object which will produce or consume the data sent over the
+ * intercepted Guacamole stream.
+ *
+ * @author Michael Jumper
+ * @param <T>
+ *     The type of object which will produce or consume the data sent over the
+ *     intercepted Guacamole stream. Usually, this will be either InputStream
+ *     or OutputStream.
+ */
+public class InterceptedStream<T extends Closeable> {
+
+    /**
+     * The index of the Guacamole stream being intercepted.
+     */
+    private final String index;
+
+    /**
+     * The stream which will produce or consume the data sent over the
+     * intercepted Guacamole stream.
+     */
+    private final T stream;
+
+    /**
+     * Creates a new InterceptedStream which associated the given Guacamole
+     * stream index with the given stream object.
+     *
+     * @param index
+     *     The index of the Guacamole stream being intercepted.
+     *
+     * @param stream
+     *     The stream which will produce or consume the data sent over the
+     *     intercepted Guacamole stream.
+     */
+    public InterceptedStream(String index, T stream) {
+        this.index = index;
+        this.stream = stream;
+    }
+
+    /**
+     * Returns the index of the Guacamole stream being intercepted.
+     *
+     * @return
+     *     The index of the Guacamole stream being intercepted.
+     */
+    public String getIndex() {
+        return index;
+    }
+
+    /**
+     * Returns the stream which will produce or consume the data sent over the
+     * intercepted Guacamole stream.
+     *
+     * @return
+     *     The stream which will produce or consume the data sent over the
+     *     intercepted Guacamole stream.
+     */
+    public T getStream() {
+        return stream;
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStream.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStream.java
@@ -20,6 +20,8 @@
 package org.apache.guacamole.tunnel;
 
 import java.io.Closeable;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.protocol.GuacamoleStatus;
 
 /**
  * A simple pairing of the index of an intercepted Guacamole stream with the
@@ -44,6 +46,13 @@ public class InterceptedStream<T extends Closeable> {
      * intercepted Guacamole stream.
      */
     private final T stream;
+
+    /**
+     * The exception which prevented the stream from completing successfully,
+     * if any. If the stream completed successfully, or has not encountered any
+     * exception yet, this will be null.
+     */
+    private GuacamoleException streamError = null;
 
     /**
      * Creates a new InterceptedStream which associated the given Guacamole
@@ -81,6 +90,72 @@ public class InterceptedStream<T extends Closeable> {
      */
     public T getStream() {
         return stream;
+    }
+
+    /**
+     * Reports that this InterceptedStream did not complete successfully due to
+     * the given GuacamoleException, which could not be thrown at the time due
+     * to asynchronous handling of the stream contents.
+     *
+     * @param streamError
+     *     The exception which prevented the stream from completing
+     *     successfully.
+     */
+    public void setStreamError(GuacamoleException streamError) {
+        this.streamError = streamError;
+    }
+
+    /**
+     * Reports that this InterceptedStream did not complete successfully due to
+     * an error described by the given status code and human-readable message.
+     * The error reported by this call can later be retrieved as a
+     * GuacamoleStreamException by calling getStreamError().
+     *
+     * @param code
+     *     The Guacamole protocol status code which described the error that
+     *     occurred. This should be taken directly from the "ack" instruction
+     *     that reported the error witin the intercepted stream.
+     *
+     * @param message
+     *     A human-readable message describing the error that occurred. This
+     *     should be taken directly from the "ack" instruction that reported
+     *     the error witin the intercepted stream.
+     */
+    public void setStreamError(int code, String message) {
+
+        // Map status code to GuacamoleStatus, assuming SERVER_ERROR by default
+        GuacamoleStatus status = GuacamoleStatus.fromGuacamoleStatusCode(code);
+        if (status == null)
+            status = GuacamoleStatus.SERVER_ERROR;
+
+        // Associate stream with corresponding GuacamoleStreamException
+        setStreamError(new GuacamoleStreamException(status, message));
+
+    }
+
+    /**
+     * Returns whether an error has prevented this InterceptedStream from
+     * completing successfully. This will return false if the stream has
+     * completed successfully OR if the stream simply has not yet completed.
+     *
+     * @return
+     *     true if an error has prevented this InterceptedStream from
+     *     completing successfully, false otherwise.
+     */
+    public boolean hasStreamError() {
+        return streamError != null;
+    }
+
+    /**
+     * Returns a GuacamoleException which describes why this InterceptedStream
+     * did not complete successfully.
+     *
+     * @return
+     *     An exception describing the error that prevented the stream from
+     *     completing successfully, or null if no such error has occurred.
+     */
+    public GuacamoleException getStreamError() {
+        return streamError;
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStreamMap.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/InterceptedStreamMap.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Map-like storage for intercepted Guacamole streams.
+ *
+ * @author Michael Jumper
+ * @param <T>
+ *     The type of object which will produce or consume the data sent over the
+ *     intercepted Guacamole stream. Usually, this will be either InputStream
+ *     or OutputStream.
+ */
+public class InterceptedStreamMap<T extends Closeable> {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(InterceptedStreamMap.class);
+
+    /**
+     * The maximum number of milliseconds to wait for notification that a
+     * stream has closed before explicitly checking for closure ourselves.
+     */
+    private static final long STREAM_WAIT_TIMEOUT = 1000;
+
+    /**
+     * Mapping of the indexes of all streams whose associated "blob" and "end"
+     * instructions should be intercepted.
+     */
+    private final ConcurrentMap<String, InterceptedStream<T>> streams =
+            new ConcurrentHashMap<String, InterceptedStream<T>>();
+
+    /**
+     * Closes the given stream, logging any errors that occur during closure.
+     * The monitor of the stream is notified via a single call to notify() once
+     * the attempt to close has been made.
+     *
+     * @param stream
+     *     The stream to close and notify.
+     */
+    private void close(T stream) {
+
+        // Attempt to close stream
+        try {
+            stream.close();
+        }
+        catch (IOException e) {
+            logger.warn("Unable to close intercepted stream: {}", e.getMessage());
+            logger.debug("I/O error prevented closure of intercepted stream.", e);
+        }
+
+        // Notify waiting threads that the stream has ended
+        synchronized (stream) {
+            stream.notify();
+        }
+
+    }
+
+    /**
+     * Closes the stream object associated with the stream having the given
+     * index, if any, removing it from the map, logging any errors that occur
+     * during closure, and unblocking any in-progress calls to waitFor() for
+     * that stream. If no such stream exists within this map, then this
+     * function has no effect.
+     *
+     * @param index
+     *     The index of the stream whose associated stream object should be
+     *     closed.
+     *
+     * @return
+     *     The stream associated with the given index, if the stream was stored
+     *     within this map, or null if no such stream exists.
+     */
+    public InterceptedStream<T> close(String index) {
+
+        // Remove associated stream
+        InterceptedStream<T> stream = streams.remove(index);
+        if (stream == null)
+            return null;
+
+        // Close stream if it exists
+        close(stream.getStream());
+        return stream;
+
+    }
+
+    /**
+     * Closes the given stream, logging any errors that occur during closure,
+     * and unblocking any in-progress calls to waitFor() for the given stream.
+     * If the given stream is stored within this map, it will also be removed.
+     *
+     * @param stream
+     *     The stream to close.
+     *
+     * @return
+     *     true if the given stream was stored within this map, false
+     *     otherwise.
+     */
+    public boolean close(InterceptedStream<T> stream) {
+
+        // Remove stream if present
+        boolean wasRemoved = streams.remove(stream.getIndex(), stream);
+
+        // Close provided stream
+        close(stream.getStream());
+
+        return wasRemoved;
+
+    }
+
+    /**
+     * Removes and closes all streams stored within this map, logging any errors
+     * that occur during closure, and unblocking any in-progress calls to
+     * waitFor().
+     */
+    public void closeAll() {
+
+        // Close any active streams
+        for (InterceptedStream<T> stream : streams.values())
+            close(stream.getStream());
+
+        // Remove now-useless references
+        streams.clear();
+
+    }
+
+    /**
+     * Blocks until the given stream is closed, or until another stream with
+     * the same index replaces it.
+     *
+     * @param stream
+     *     The stream to wait for.
+     */
+    public void waitFor(InterceptedStream<T> stream) {
+
+        T underlyingStream = stream.getStream();
+
+        // Wait for stream to close
+        synchronized (underlyingStream) {
+            while (streams.get(stream.getIndex()) == stream) {
+                try {
+                    underlyingStream.wait(STREAM_WAIT_TIMEOUT);
+                }
+                catch (InterruptedException e) {
+                    // Ignore
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Returns the stream stored in this map under the given index.
+     *
+     * @param index
+     *     The index of the stream to return.
+     *
+     * @return
+     *     The stream having the given index, or null if no such stream is
+     *     stored within this map.
+     */
+    public InterceptedStream<T> get(String index) {
+        return streams.get(index);
+    }
+
+    /**
+     * Adds the given stream to this map, storing it under its associated
+     * index. If another stream already exists within this map having the same
+     * index, that stream will be closed and replaced.
+     *
+     * @param stream
+     *     The stream to store within this map.
+     */
+    public void put(InterceptedStream<T> stream) {
+
+        // Add given stream to map
+        InterceptedStream<T> oldStream =
+                streams.put(stream.getIndex(), stream);
+
+        // If a previous stream DID exist, close it
+        if (oldStream != null)
+            close(oldStream.getStream());
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/OutputStreamInterceptingFilter.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/OutputStreamInterceptingFilter.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import javax.xml.bind.DatatypeConverter;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.protocol.GuacamoleInstruction;
+import org.apache.guacamole.protocol.GuacamoleStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter which selectively intercepts "blob" and "end" instructions,
+ * automatically writing to or closing the stream given with
+ * interceptStream(). The required "ack" responses to received blobs are
+ * sent automatically.
+ *
+ * @author Michael Jumper
+ */
+public class OutputStreamInterceptingFilter
+        extends StreamInterceptingFilter<OutputStream> {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger =
+            LoggerFactory.getLogger(OutputStreamInterceptingFilter.class);
+
+    /**
+     * Creates a new OutputStreamInterceptingFilter which selectively intercepts
+     * "blob" and "end" instructions. The required "ack" responses will
+     * automatically be sent over the given tunnel.
+     *
+     * @param tunnel
+     *     The GuacamoleTunnel over which any required "ack" instructions
+     *     should be sent.
+     */
+    public OutputStreamInterceptingFilter(GuacamoleTunnel tunnel) {
+        super(tunnel);
+    }
+
+    /**
+     * Injects an "ack" instruction into the outbound Guacamole protocol
+     * stream, as if sent by the connected client. "ack" instructions are used
+     * to acknowledge the receipt of a stream and its subsequent blobs, and are
+     * the only means of communicating success/failure status.
+     *
+     * @param index
+     *     The index of the stream that this "ack" instruction relates to.
+     *
+     * @param message
+     *     An arbitrary human-readable message to include within the "ack"
+     *     instruction.
+     *
+     * @param status
+     *     The status of the stream operation being acknowledged via the "ack"
+     *     instruction. Error statuses will implicitly close the stream via
+     *     closeStream().
+     */
+    private void sendAck(String index, String message, GuacamoleStatus status) {
+
+        // Error "ack" instructions implicitly close the stream
+        if (status != GuacamoleStatus.SUCCESS)
+            closeInterceptedStream(index);
+
+        sendInstruction(new GuacamoleInstruction("ack", index, message,
+                Integer.toString(status.getGuacamoleStatusCode())));
+
+    }
+
+    /**
+     * Handles a single "blob" instruction, decoding its base64 data,
+     * sending that data to the associated OutputStream, and ultimately
+     * dropping the "blob" instruction such that the client never receives
+     * it. If no OutputStream is associated with the stream index within
+     * the "blob" instruction, the instruction is passed through untouched.
+     *
+     * @param instruction
+     *     The "blob" instruction being handled.
+     *
+     * @return
+     *     The originally-provided "blob" instruction, if that instruction
+     *     should be passed through to the client, or null if the "blob"
+     *     instruction should be dropped.
+     */
+    private GuacamoleInstruction handleBlob(GuacamoleInstruction instruction) {
+
+        // Verify all required arguments are present
+        List<String> args = instruction.getArgs();
+        if (args.size() < 2)
+            return instruction;
+
+        // Pull associated stream
+        String index = args.get(0);
+        InterceptedStream<OutputStream> stream = getInterceptedStream(index);
+        if (stream == null)
+            return instruction;
+
+        // Decode blob
+        byte[] blob;
+        try {
+            String data = args.get(1);
+            blob = DatatypeConverter.parseBase64Binary(data);
+        }
+        catch (IllegalArgumentException e) {
+            logger.warn("Received base64 data for intercepted stream was invalid.");
+            logger.debug("Decoding base64 data for intercepted stream failed.", e);
+            return null;
+        }
+
+        // Attempt to write data to stream
+        try {
+            stream.getStream().write(blob);
+            sendAck(index, "OK", GuacamoleStatus.SUCCESS);
+        }
+        catch (IOException e) {
+            sendAck(index, "FAIL", GuacamoleStatus.SERVER_ERROR);
+            logger.debug("Write failed for intercepted stream.", e);
+        }
+
+        // Instruction was handled purely internally
+        return null;
+
+    }
+
+    /**
+     * Handles a single "end" instruction, closing the associated
+     * OutputStream. If no OutputStream is associated with the stream index
+     * within the "end" instruction, this function has no effect.
+     *
+     * @param instruction
+     *     The "end" instruction being handled.
+     */
+    private void handleEnd(GuacamoleInstruction instruction) {
+
+        // Verify all required arguments are present
+        List<String> args = instruction.getArgs();
+        if (args.size() < 1)
+            return;
+
+        // Terminate stream
+        closeInterceptedStream(args.get(0));
+
+    }
+
+    @Override
+    public GuacamoleInstruction filter(GuacamoleInstruction instruction)
+            throws GuacamoleException {
+
+        // Intercept "blob" instructions for in-progress streams
+        if (instruction.getOpcode().equals("blob"))
+            return handleBlob(instruction);
+
+        // Intercept "end" instructions for in-progress streams
+        if (instruction.getOpcode().equals("end")) {
+            handleEnd(instruction);
+            return instruction;
+        }
+
+        // Pass instruction through untouched
+        return instruction;
+
+    }
+
+    @Override
+    protected void handleInterceptedStream(InterceptedStream<OutputStream> stream) {
+
+        // Acknowledge that the stream is ready to receive data
+        sendAck(stream.getIndex(), "OK", GuacamoleStatus.SUCCESS);
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingFilter.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingFilter.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.tunnel;
+
+import java.io.Closeable;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.io.GuacamoleWriter;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.protocol.GuacamoleFilter;
+import org.apache.guacamole.protocol.GuacamoleInstruction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter which selectively intercepts stream-related instructions,
+ * automatically writing to, reading from, or closing the stream given with
+ * interceptStream(). Any instructions required by the Guacamole protocol to be
+ * sent in response to intercepted instructions will be sent automatically.
+ *
+ * @param <T>
+ *     The type of object which will produce or consume the data sent over the
+ *     intercepted Guacamole stream. Usually, this will be either InputStream
+ *     or OutputStream.
+ */
+public abstract class StreamInterceptingFilter<T extends Closeable>
+        implements GuacamoleFilter {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger =
+            LoggerFactory.getLogger(StreamInterceptingFilter.class);
+
+    /**
+     * Mapping of the all streams whose related instructions should be
+     * intercepted.
+     */
+    private final InterceptedStreamMap<T> streams = new InterceptedStreamMap<T>();
+
+    /**
+     * The tunnel over which any required instructions should be sent.
+     */
+    private final GuacamoleTunnel tunnel;
+
+    /**
+     * Creates a new StreamInterceptingFilter which selectively intercepts
+     * stream-related instructions. Any instructions required by the Guacamole
+     * protocol to be sent in response to intercepted instructions will be sent
+     * automatically over the given tunnel.
+     *
+     * @param tunnel
+     *     The GuacamoleTunnel over which any required instructions should be
+     *     sent.
+     */
+    public StreamInterceptingFilter(GuacamoleTunnel tunnel) {
+        this.tunnel = tunnel;
+    }
+
+    /**
+     * Injects an arbitrary Guacamole instruction into the outbound Guacamole
+     * protocol stream (GuacamoleWriter) of the tunnel associated with this
+     * StreamInterceptingFilter, as if the instruction was sent by the connected
+     * client.
+     *
+     * @param instruction
+     *     The Guacamole instruction to inject.
+     */
+    protected void sendInstruction(GuacamoleInstruction instruction) {
+
+        // Temporarily acquire writer to send "ack" instruction
+        GuacamoleWriter writer = tunnel.acquireWriter();
+
+        // Send successful "ack"
+        try {
+            writer.writeInstruction(instruction);
+        }
+        catch (GuacamoleException e) {
+            logger.debug("Unable to send \"{}\" for intercepted stream.",
+                    instruction.getOpcode(), e);
+        }
+
+        // Done writing
+        tunnel.releaseWriter();
+
+    }
+
+    /**
+     * Returns the stream having the given index and currently being intercepted
+     * by this filter.
+     *
+     * @param index
+     *     The index of the stream to return.
+     *
+     * @return
+     *     The stream having the given index, or null if no such stream is
+     *     being intercepted.
+     */
+    protected InterceptedStream<T> getInterceptedStream(String index) {
+        return streams.get(index);
+    }
+
+    /**
+     * Closes the stream having the given index and currently being intercepted
+     * by this filter, if any. If no such stream is being intercepted, then this
+     * function has no effect.
+     *
+     * @param index
+     *     The index of the stream to close.
+     *
+     * @return
+     *     The stream associated with the given index, if the stream is being
+     *     intercepted, or null if no such stream exists.
+     */
+    protected InterceptedStream<T> closeInterceptedStream(String index) {
+        return streams.close(index);
+    }
+
+    /**
+     * Closes the given stream.
+     *
+     * @param stream
+     *     The stream to close.
+     *
+     * @return
+     *     true if the given stream was being intercepted, false otherwise.
+     */
+    protected boolean closeInterceptedStream(InterceptedStream<T> stream) {
+        return streams.close(stream);
+    }
+
+    /**
+     * Closes all streams being intercepted by this filter.
+     */
+    public void closeAllInterceptedStreams() {
+        streams.closeAll();
+    }
+
+    /**
+     * Begins handling the data of the given intercepted stream. This function
+     * will automatically be invoked by interceptStream() for any valid stream.
+     * It is not required that this function block until all data is handled;
+     * interceptStream() will do this automatically. Implementations are free
+     * to use asynchronous approaches to data handling.
+     *
+     * @param stream
+     *     The stream being intercepted.
+     */
+    protected abstract void handleInterceptedStream(InterceptedStream<T> stream);
+
+    /**
+     * Intercept the stream having the given index, producing or consuming its
+     * data as appropriate. The given stream object will automatically be closed
+     * when the stream ends. If there is no stream having the given index, then
+     * the stream object will be closed immediately. This function will block
+     * until all data has been handled and the stream is ended.
+     *
+     * @param index
+     *     The index of the stream to intercept.
+     *
+     * @param stream
+     *     The stream object which will produce or consume all data for the
+     *     stream having the given index.
+     */
+    public void interceptStream(int index, T stream) {
+
+        InterceptedStream<T> interceptedStream;
+        String indexString = Integer.toString(index);
+
+        // Atomically verify tunnel is open and add the given stream
+        synchronized (tunnel) {
+
+            // Do nothing if tunnel is not open
+            if (!tunnel.isOpen())
+                return;
+
+            // Wrap stream
+            interceptedStream = new InterceptedStream<T>(indexString, stream);
+
+            // Replace any existing stream
+            streams.put(interceptedStream);
+
+        }
+
+        // Produce/consume all stream data
+        handleInterceptedStream(interceptedStream);
+
+        // Wait for stream to close
+        streams.waitFor(interceptedStream);
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingFilter.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingFilter.java
@@ -177,8 +177,12 @@ public abstract class StreamInterceptingFilter<T extends Closeable>
      * @param stream
      *     The stream object which will produce or consume all data for the
      *     stream having the given index.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while intercepting the stream, or if the stream
+     *     itself reports an error.
      */
-    public void interceptStream(int index, T stream) {
+    public void interceptStream(int index, T stream) throws GuacamoleException {
 
         InterceptedStream<T> interceptedStream;
         String indexString = Integer.toString(index);
@@ -203,6 +207,10 @@ public abstract class StreamInterceptingFilter<T extends Closeable>
 
         // Wait for stream to close
         streams.waitFor(interceptedStream);
+
+        // Throw any asynchronously-provided exception
+        if (interceptedStream.hasStreamError())
+            throw interceptedStream.getStreamError();
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingTunnel.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingTunnel.java
@@ -85,18 +85,27 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
      *
      * @param stream
      *     The OutputStream to write all intercepted data to.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while intercepting the stream, or if the stream
+     *     itself reports an error.
      */
-    public void interceptStream(int index, OutputStream stream) {
+    public void interceptStream(int index, OutputStream stream)
+            throws GuacamoleException {
 
         // Log beginning of intercepted stream
         logger.debug("Intercepting output stream #{} of tunnel \"{}\".",
                 index, getUUID());
 
-        outputStreamFilter.interceptStream(index, new BufferedOutputStream(stream));
+        try {
+            outputStreamFilter.interceptStream(index, new BufferedOutputStream(stream));
+        }
 
         // Log end of intercepted stream
-        logger.debug("Intercepted output stream #{} of tunnel \"{}\" ended.",
-                index, getUUID());
+        finally {
+            logger.debug("Intercepted output stream #{} of tunnel \"{}\" ended.",
+                    index, getUUID());
+        }
 
     }
 
@@ -113,18 +122,27 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
      *
      * @param stream
      *     The InputStream to read all blobs data from.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while intercepting the stream, or if the stream
+     *     itself reports an error.
      */
-    public void interceptStream(int index, InputStream stream) {
+    public void interceptStream(int index, InputStream stream)
+            throws GuacamoleException {
 
         // Log beginning of intercepted stream
         logger.debug("Intercepting input stream #{} of tunnel \"{}\".",
                 index, getUUID());
 
-        inputStreamFilter.interceptStream(index, new BufferedInputStream(stream));
+        try {
+            inputStreamFilter.interceptStream(index, new BufferedInputStream(stream));
+        }
 
         // Log end of intercepted stream
-        logger.debug("Intercepted input stream #{} of tunnel \"{}\" ended.",
-                index, getUUID());
+        finally {
+            logger.debug("Intercepted input stream #{} of tunnel \"{}\" ended.",
+                    index, getUUID());
+        }
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingTunnel.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/StreamInterceptingTunnel.java
@@ -20,21 +20,12 @@
 package org.apache.guacamole.tunnel;
 
 import java.io.BufferedOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import javax.xml.bind.DatatypeConverter;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.io.GuacamoleReader;
-import org.apache.guacamole.io.GuacamoleWriter;
 import org.apache.guacamole.net.DelegatingGuacamoleTunnel;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.protocol.FilteredGuacamoleReader;
-import org.apache.guacamole.protocol.GuacamoleFilter;
-import org.apache.guacamole.protocol.GuacamoleInstruction;
-import org.apache.guacamole.protocol.GuacamoleStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,13 +42,8 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
     /**
      * Logger for this class.
      */
-    private static final Logger logger = LoggerFactory.getLogger(StreamInterceptingTunnel.class);
-
-    /**
-     * The maximum number of milliseconds to wait for notification that a
-     * stream has closed before explicitly checking for closure ourselves.
-     */
-    private static final long STREAM_WAIT_TIMEOUT = 1000;
+    private static final Logger logger =
+            LoggerFactory.getLogger(StreamInterceptingTunnel.class);
 
     /**
      * Creates a new StreamInterceptingTunnel which wraps the given tunnel,
@@ -73,206 +59,10 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
     }
 
     /**
-     * Mapping of the indexes of all streams whose associated "blob" and "end"
-     * instructions should be intercepted.
+     * The filter to use for rerouting received stream data to OutputStreams.
      */
-    private final Map<String, OutputStream> streams =
-            new ConcurrentHashMap<String, OutputStream>();
-
-    /**
-     * Filter which selectively intercepts "blob" and "end" instructions,
-     * automatically writing to or closing the stream given with
-     * interceptStream(). The required "ack" responses to received blobs are
-     * sent automatically.
-     */
-    private final GuacamoleFilter STREAM_FILTER = new GuacamoleFilter() {
-
-        /**
-         * Handles a single "blob" instruction, decoding its base64 data,
-         * sending that data to the associated OutputStream, and ultimately
-         * dropping the "blob" instruction such that the client never receives
-         * it. If no OutputStream is associated with the stream index within
-         * the "blob" instruction, the instruction is passed through untouched.
-         *
-         * @param instruction
-         *     The "blob" instruction being handled.
-         *
-         * @return
-         *     The originally-provided "blob" instruction, if that instruction
-         *     should be passed through to the client, or null if the "blob"
-         *     instruction should be dropped.
-         */
-        private GuacamoleInstruction handleBlob(GuacamoleInstruction instruction) {
-
-            // Verify all required arguments are present
-            List<String> args = instruction.getArgs();
-            if (args.size() < 2)
-                return instruction;
-
-            // Pull associated stream
-            String index = args.get(0);
-            OutputStream stream = streams.get(index);
-            if (stream == null)
-                return instruction;
-
-            // Decode blob
-            byte[] blob;
-            try {
-                String data = args.get(1);
-                blob = DatatypeConverter.parseBase64Binary(data);
-            }
-            catch (IllegalArgumentException e) {
-                logger.warn("Received base64 data for intercepted stream was invalid.");
-                logger.debug("Decoding base64 data for intercepted stream failed.", e);
-                return null;
-            }
-
-            // Attempt to write data to stream
-            try {
-                stream.write(blob);
-                sendAck(index, "OK", GuacamoleStatus.SUCCESS);
-            }
-            catch (IOException e) {
-                sendAck(index, "FAIL", GuacamoleStatus.SERVER_ERROR);
-                logger.debug("Write failed for intercepted stream.", e);
-            }
-
-            // Instruction was handled purely internally
-            return null;
-
-        }
-
-        /**
-         * Handles a single "end" instruction, closing the associated
-         * OutputStream. If no OutputStream is associated with the stream index
-         * within the "end" instruction, this function has no effect.
-         *
-         * @param instruction
-         *     The "end" instruction being handled.
-         */
-        private void handleEnd(GuacamoleInstruction instruction) {
-
-            // Verify all required arguments are present
-            List<String> args = instruction.getArgs();
-            if (args.size() < 1)
-                return;
-
-            // Terminate stream
-            closeStream(args.get(0));
-
-        }
-
-        @Override
-        public GuacamoleInstruction filter(GuacamoleInstruction instruction)
-                throws GuacamoleException {
-
-            // Intercept "blob" instructions for in-progress streams
-            if (instruction.getOpcode().equals("blob"))
-                return handleBlob(instruction);
-
-            // Intercept "end" instructions for in-progress streams
-            if (instruction.getOpcode().equals("end")) {
-                handleEnd(instruction);
-                return instruction;
-            }
-
-            // Pass instruction through untouched
-            return instruction;
-
-        }
-
-    };
-
-    /**
-     * Closes the given OutputStream, logging any errors that occur during
-     * closure. The monitor of the OutputStream is notified via a single call
-     * to notify() once the attempt to close has been made.
-     *
-     * @param stream
-     *     The OutputStream to close and notify.
-     */
-    private void closeStream(OutputStream stream) {
-
-        // Attempt to close stream
-        try {
-            stream.close();
-        }
-        catch (IOException e) {
-            logger.warn("Unable to close intercepted stream: {}", e.getMessage());
-            logger.debug("I/O error prevented closure of intercepted stream.", e);
-        }
-
-        // Notify waiting threads that the stream has ended
-        synchronized (stream) {
-            stream.notify();
-        }
-
-    }
-
-    /**
-     * Closes the OutputStream associated with the stream having the given
-     * index, if any, logging any errors that occur during closure. If no such
-     * stream exists, this function has no effect. The monitor of the
-     * OutputStream is notified via a single call to notify() once the attempt
-     * to close has been made.
-     *
-     * @param index
-     *     The index of the stream whose associated OutputStream should be
-     *     closed and notified.
-     */
-    private OutputStream closeStream(String index) {
-
-        // Remove associated stream
-        OutputStream stream = streams.remove(index);
-        if (stream == null)
-            return null;
-
-        // Close stream if it exists
-        closeStream(stream);
-        return stream;
-
-    }
-
-    /**
-     * Injects an "ack" instruction into the outbound Guacamole protocol
-     * stream, as if sent by the connected client. "ack" instructions are used
-     * to acknowledge the receipt of a stream and its subsequent blobs, and are
-     * the only means of communicating success/failure status.
-     *
-     * @param index
-     *     The index of the stream that this "ack" instruction relates to.
-     *
-     * @param message
-     *     An arbitrary human-readable message to include within the "ack"
-     *     instruction.
-     *
-     * @param status
-     *     The status of the stream operation being acknowledged via the "ack"
-     *     instruction. Error statuses will implicitly close the stream via
-     *     closeStream().
-     */
-    private void sendAck(String index, String message, GuacamoleStatus status) {
-
-        // Temporarily acquire writer to send "ack" instruction
-        GuacamoleWriter writer = acquireWriter();
-
-        // Send successful "ack"
-        try {
-            writer.writeInstruction(new GuacamoleInstruction("ack", index, message,
-                    Integer.toString(status.getGuacamoleStatusCode())));
-        }
-        catch (GuacamoleException e) {
-            logger.debug("Unable to send \"ack\" for intercepted stream.", e);
-        }
-
-        // Error "ack" instructions implicitly close the stream
-        if (status != GuacamoleStatus.SUCCESS)
-            closeStream(index);
-
-        // Done writing
-        releaseWriter();
-
-    }
+    private final OutputStreamInterceptingFilter outputStreamFilter =
+            new OutputStreamInterceptingFilter(this);
 
     /**
      * Intercept all data received along the stream having the given index,
@@ -290,57 +80,21 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
      */
     public void interceptStream(int index, OutputStream stream) {
 
-        String indexString = Integer.toString(index);
-
-        // Atomically verify tunnel is open and add the given stream
-        OutputStream oldStream;
-        synchronized (this) {
-
-            // Do nothing if tunnel is not open
-            if (!isOpen()) {
-                closeStream(stream);
-                return;
-            }
-
-            // Wrap stream
-            stream = new BufferedOutputStream(stream);
-
-            // Replace any existing stream
-            oldStream = streams.put(indexString, stream);
-
-        }
-
-        // If a previous stream DID exist, close it
-        if (oldStream != null)
-            closeStream(oldStream);
-
         // Log beginning of intercepted stream
-        logger.debug("Intercepting stream #{} of tunnel \"{}\".",
+        logger.debug("Intercepting output stream #{} of tunnel \"{}\".",
                 index, getUUID());
 
-        // Acknowledge stream receipt
-        sendAck(indexString, "OK", GuacamoleStatus.SUCCESS);
-
-        // Wait for stream to close
-        synchronized (stream) {
-            while (streams.get(indexString) == stream) {
-                try {
-                    stream.wait(STREAM_WAIT_TIMEOUT);
-                }
-                catch (InterruptedException e) {
-                    // Ignore
-                }
-            }
-        }
+        outputStreamFilter.interceptStream(index, new BufferedOutputStream(stream));
 
         // Log end of intercepted stream
-        logger.debug("Intercepted stream #{} of tunnel \"{}\" ended.", index, getUUID());
+        logger.debug("Intercepted output stream #{} of tunnel \"{}\" ended.",
+                index, getUUID());
 
     }
 
     @Override
     public GuacamoleReader acquireReader() {
-        return new FilteredGuacamoleReader(super.acquireReader(), STREAM_FILTER);
+        return new FilteredGuacamoleReader(super.acquireReader(), outputStreamFilter);
     }
 
     @Override
@@ -352,16 +106,9 @@ public class StreamInterceptingTunnel extends DelegatingGuacamoleTunnel {
             super.close();
         }
 
-        // Ensure all waiting threads are notified that all streams have ended
+        // Close all intercepted streams
         finally {
-
-            // Close any active streams
-            for (OutputStream stream : streams.values())
-                closeStream(stream);
-
-            // Remove now-useless references
-            streams.clear();
-
+            outputStreamFilter.closeAllInterceptedStreams();
         }
 
     }

--- a/guacamole/src/main/webapp/app/rest/types/Error.js
+++ b/guacamole/src/main/webapp/app/rest/types/Error.js
@@ -43,6 +43,14 @@ angular.module('rest').factory('Error', [function defineError() {
         this.message = template.message;
 
         /**
+         * The Guacamole protocol status code associated with the error that
+         * occurred. This is only valid for errors of type STREAM_ERROR.
+         *
+         * @type Number
+         */
+        this.statusCode = template.statusCode;
+
+        /**
          * The type string defining which values this parameter may contain,
          * as well as what properties are applicable. Valid types are listed
          * within Error.Type.
@@ -110,7 +118,16 @@ angular.module('rest').factory('Error', [function defineError() {
          *
          * @type String
          */
-        PERMISSION_DENIED : 'PERMISSION_DENIED'
+        PERMISSION_DENIED : 'PERMISSION_DENIED',
+
+        /**
+         * An error occurred within an intercepted stream, terminating that
+         * stream. The Guacamole protocol status code of that error will be
+         * stored within statusCode.
+         *
+         * @type String
+         */
+        STREAM_ERROR : 'STREAM_ERROR'
 
     };
 


### PR DESCRIPTION
Similar to apache/incubator-guacamole-client#13, this change implements the upload half of the tunnel REST endpoint. While it is possible to upload using JavaScript alone via the new `Guacamole.FileWriter` added via apache/incubator-guacamole-client#14, doing so instead via native HTTP is **much faster**.

To facilitate translation of Guacamole protocol status codes (received via "ack" instructions along the stream) to HTTP errors and `APIError` entities, this change also:

1. Adds a new `fromGuacamoleStatusCode()` to the `GuacamoleStatus` enum, allowing the integer status codes to be directly translated to typesafe `GuacamoleStatus` values.
2. Adds a new `statusCode` property to `APIError` (and it's JavaScript sibling `Error`), along with a new error type, `STREAM_ERROR`, for the sake of representing errors received along an intercepted Guacamole stream.

The logic surrounding routing a Guacamole stream to an `OutputStream` has been extracted and generalized such that the corresponding `InputStream` implementation can leverage much of the same logic. This is done through the following new classes:

1. `InterceptedStream` - a pairing of `OutputStream` or `InputStream` with the stream index used by the Guacamole protocol, here represented by a `String` despite its integer nature due to the way such things are represented internally. It's only parsed out as an integer when actually needed as such.
2. `InterceptedStreamMap` - a mapping of stream index (again, in `String` form) to the corresponding `InterceptedStream`. This class also automatically handles notification of stream closure, and provides its own `waitFor()` function that blocks until a given stream has closed. This logic used to be part of `StreamInterceptingTunnel` when it was `OutputStream`-specific.
3. `StreamInterceptingFilter` - a filter which intercepts stream-related instructions for streams of an arbitrary type, automatically handling mapping of stream indices and blocking. It is up to the implementation to filter the instructions it is actually interested in, and route the I/O associated with those instructions accordingly.
4. `OutputStreamInterceptingFilter` - an `OutputStream`-specific implementation of `StreamInterceptingFilter`. This contains the remaining logic that used to be part of `StreamInterceptingTunnel`.
5. `InputStreamInterceptingFilter` - an `InputStream`-specific implementation of `StreamInterceptingFilter`. This is the new logic, implementing support for routing uploaded file data along an established Guacamole stream.

As receipt of the error via "ack" happens asynchronously and outside the blocking call to `interceptStream()`, errors are instead reported via a call to the `setStreamError()` function of the newly-added `InterceptedStream` object.