### PR TITLE
GUACAMOLE-1: Interface should say "Apache Guacamole", not "Guacamole".

### DIFF
--- a/guacamole/src/main/webapp/app/login/styles/dialog.css
+++ b/guacamole/src/main/webapp/app/login/styles/dialog.css
@@ -71,11 +71,36 @@
 }
 
 .login-ui .login-dialog .version {
-    font-size: 1.25em;
-    font-weight: bold;
     padding: 0.5em 0;
+}
+
+.login-ui .login-dialog .version .app-name {
+    font-weight: bold;
     text-transform: uppercase;
     text-align: center;
+    font-size: 1.25em;
+}
+
+.login-ui .login-dialog .version .version-number {
+
+    position: absolute;
+    right: 0;
+    bottom: 0;
+
+    padding: 0.25em 0.75em;
+    margin: 0.25em;
+
+    -moz-border-radius: 0.5em;
+    -webkit-border-radius: 0.5em;
+    -khtml-border-radius: 0.5em;
+    border-radius: 0.5em;
+
+    color: white;
+    background: green;
+    font-size: 0.5em;
+    font-style: italic;
+    opacity: 0.5;
+
 }
 
 .login-ui .login-dialog .logo {

--- a/guacamole/src/main/webapp/app/login/templates/login.html
+++ b/guacamole/src/main/webapp/app/login/templates/login.html
@@ -11,7 +11,10 @@
 
                 <!-- Guacamole version -->
                 <div class="logo"></div>
-                <div class="version">{{'APP.NAME' | translate}}</div>
+                <div class="version">
+                    <div class="app-name">{{'APP.NAME' | translate}}</div>
+                    <div class="version-number">{{'APP.VERSION' | translate}}</div>
+                </div>
 
                 <!-- Login message/instructions -->
                 <p ng-show="helpText">{{helpText | translate}}</p>

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -38,8 +38,6 @@
 
         "INFO_ACTIVE_USER_COUNT" : "In Benutzung durch {USERS} Benutzer.",
 
-        "NAME" : "Apache Guacamole ${project.version}",
-
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{Sekunde} other{Sekunden}}} minute{{VALUE, plural, one{Minute} other{Minuten}}} hour{{VALUE, plural, one{Stunde} other{Stunden}}} day{{VALUE, plural, one{Tag} other{Tage}}} other{}}"
 
     },

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -38,7 +38,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "In Benutzung durch {USERS} Benutzer.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{Sekunde} other{Sekunden}}} minute{{VALUE, plural, one{Minute} other{Minuten}}} hour{{VALUE, plural, one{Stunde} other{Stunden}}} day{{VALUE, plural, one{Tag} other{Tage}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Cancel",
         "ACTION_CLONE"              : "Clone",
@@ -37,8 +40,6 @@
         "FORMAT_DATE_TIME_PRECISE" : "yyyy-MM-dd HH:mm:ss",
 
         "INFO_ACTIVE_USER_COUNT" : "Currently in use by {USERS} {USERS, plural, one{user} other{users}}.",
-
-        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -38,7 +38,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Currently in use by {USERS} {USERS, plural, one{user} other{users}}.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -38,8 +38,6 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Actuellement utilisé par {USERS} {USERS, plural, one{utilisateur} other{utilisateurs}}.",
 
-        "NAME" : "Apache Guacamole ${project.version}",
-
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{seconde} other{secondes}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{heure} other{heures}}} day{{VALUE, plural, one{jour} other{jours}}} other{}}"
 
     },

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -38,7 +38,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Actuellement utilisé par {USERS} {USERS, plural, one{utilisateur} other{utilisateurs}}.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{seconde} other{secondes}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{heure} other{heures}}} day{{VALUE, plural, one{jour} other{jours}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/it.json
+++ b/guacamole/src/main/webapp/translations/it.json
@@ -36,7 +36,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Ora utilizzato da {USERS} {USERS, plural, one{user} other{users}}.",
 
-        "NAME" : "Guacamole ${project.version}"
+        "NAME" : "Apache Guacamole ${project.version}"
 
     },
 

--- a/guacamole/src/main/webapp/translations/it.json
+++ b/guacamole/src/main/webapp/translations/it.json
@@ -34,9 +34,7 @@
 
         "FORMAT_DATE_TIME_PRECISE" : "dd-MM-yyyy HH:mm:ss",
 
-        "INFO_ACTIVE_USER_COUNT" : "Ora utilizzato da {USERS} {USERS, plural, one{user} other{users}}.",
-
-        "NAME" : "Apache Guacamole ${project.version}"
+        "INFO_ACTIVE_USER_COUNT" : "Ora utilizzato da {USERS} {USERS, plural, one{user} other{users}}."
 
     },
 

--- a/guacamole/src/main/webapp/translations/nl.json
+++ b/guacamole/src/main/webapp/translations/nl.json
@@ -38,8 +38,6 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Op dit moment in gebruik door {USERS} {USERS, plural, one{gebruiker} other{gebruikers}}.",
 
-        "NAME" : "Apache Guacamole ${project.version}",
-
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{seconde} other{seconden}}} minute{{VALUE, plural, one{minuut} other{minuten}}} hour{{VALUE, plural, one{uur} other{uren}}} day{{VALUE, plural, one{dag} other{dagen}}} other{}}"
 
     },

--- a/guacamole/src/main/webapp/translations/nl.json
+++ b/guacamole/src/main/webapp/translations/nl.json
@@ -38,7 +38,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Op dit moment in gebruik door {USERS} {USERS, plural, one{gebruiker} other{gebruikers}}.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{seconde} other{seconden}}} minute{{VALUE, plural, one{minuut} other{minuten}}} hour{{VALUE, plural, one{uur} other{uren}}} day{{VALUE, plural, one{dag} other{dagen}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/ru.json
+++ b/guacamole/src/main/webapp/translations/ru.json
@@ -35,7 +35,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Подключено пользователей {USERS}.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Apache Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{секунда} other{сек}}} minute{{VALUE, plural, one{минута} other{мин}}} hour{{VALUE, plural, one{час} other{ч}}} day{{VALUE, plural, one{день} other{дн}}} other{}}"
 

--- a/guacamole/src/main/webapp/translations/ru.json
+++ b/guacamole/src/main/webapp/translations/ru.json
@@ -35,8 +35,6 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Подключено пользователей {USERS}.",
 
-        "NAME" : "Apache Guacamole ${project.version}",
-
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{секунда} other{сек}}} minute{{VALUE, plural, one{минута} other{мин}}} hour{{VALUE, plural, one{час} other{ч}}} day{{VALUE, plural, one{день} other{дн}}} other{}}"
 
     },


### PR DESCRIPTION
This change updates the application name from "Guacamole" to "Apache Guacamole" via the translation strings. As the version number is now quite long, I've also separated the old `APP.NAME` into `APP.NAME` and `APP.VERSION`, and reorganized the login screen to keep things clean:

> ![apache-guac-login](https://cloud.githubusercontent.com/assets/4632905/15949590/97a385ee-2e5d-11e6-8d97-7df3217665da.png)
