### PR TITLE
GUACAMOLE-50: Update Docker container to use Java 8

### DIFF
--- a/guacamole-docker/Dockerfile
+++ b/guacamole-docker/Dockerfile
@@ -22,7 +22,7 @@
 #
 
 # Start from Tomcat image
-FROM tomcat:8.0.20-jre7
+FROM tomcat:8.0.20-jre8
 MAINTAINER Michael Jumper <mike.jumper@guac-dev.org>
 
 # Version info


### PR DESCRIPTION
I've tested this with the MySQL auth against and RDP EC2 instance, seems to work fine.

I've also been running Guacamole in production on Java 8 for over 6 months with no known issues.