### PR TITLE
GUACAMOLE-53: Implement session affinity for balancing groups

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
@@ -55,6 +55,12 @@ public class ConnectionGroupModel extends GroupedObjectModel {
     private Integer maxConnectionsPerUser;
 
     /**
+     * Whether individual users should be consistently assigned the same
+     * connection within a balancing group until they log out.
+     */
+    private boolean sessionAffinityEnabled;
+
+    /**
      * Creates a new, empty connection group.
      */
     public ConnectionGroupModel() {
@@ -154,6 +160,30 @@ public class ConnectionGroupModel extends GroupedObjectModel {
      */
     public void setMaxConnectionsPerUser(Integer maxConnectionsPerUser) {
         this.maxConnectionsPerUser = maxConnectionsPerUser;
+    }
+
+    /**
+     * Returns whether individual users should be consistently assigned the same
+     * connection within a balancing group until they log out.
+     *
+     * @return
+     *     Whether individual users should be consistently assigned the same
+     *     connection within a balancing group until they log out.
+     */
+    public boolean isSessionAffinityEnabled() {
+        return sessionAffinityEnabled;
+    }
+
+    /**
+     * Sets whether individual users should be consistently assigned the same
+     * connection within a balancing group until they log out.
+     *
+     * @param sessionAffinityEnabled
+     *     Whether individual users should be consistently assigned the same
+     *     connection within a balancing group until they log out.
+     */
+    public void setSessionAffinityEnabled(boolean sessionAffinityEnabled) {
+        this.sessionAffinityEnabled = sessionAffinityEnabled;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
@@ -26,11 +26,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.connection.ConnectionService;
-import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObject;
+import org.apache.guacamole.auth.jdbc.connection.ConnectionService;
+import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
+import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.NumericField;
@@ -68,12 +69,20 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
     public static final String MAX_CONNECTIONS_PER_USER_NAME = "max-connections-per-user";
 
     /**
+     * The name of the attribute which controls whether individual users will be
+     * consistently assigned the same connection within a balancing group until
+     * they log out.
+     */
+    public static final String ENABLE_SESSION_AFFINITY = "enable-session-affinity";
+
+    /**
      * All attributes related to restricting user accounts, within a logical
      * form.
      */
     public static final Form CONCURRENCY_LIMITS = new Form("concurrency", Arrays.<Field>asList(
         new NumericField(MAX_CONNECTIONS_NAME),
-        new NumericField(MAX_CONNECTIONS_PER_USER_NAME)
+        new NumericField(MAX_CONNECTIONS_PER_USER_NAME),
+        new BooleanField(ENABLE_SESSION_AFFINITY, "true")
     ));
 
     /**
@@ -168,6 +177,10 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
         // Set per-user connection limit attribute
         attributes.put(MAX_CONNECTIONS_PER_USER_NAME, NumericField.format(getModel().getMaxConnectionsPerUser()));
 
+        // Set session affinity attribute
+        attributes.put(ENABLE_SESSION_AFFINITY,
+                getModel().isSessionAffinityEnabled() ? "true" : "");
+
         return attributes;
     }
 
@@ -187,6 +200,10 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
             logger.warn("Not setting maximum connections per user: {}", e.getMessage());
             logger.debug("Unable to parse numeric attribute.", e);
         }
+
+        // Translate session affinity attribute
+        getModel().setSessionAffinityEnabled(
+                "true".equals(attributes.get(ENABLE_SESSION_AFFINITY)));
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
@@ -257,5 +257,16 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
 
     }
 
+    /**
+     * Returns whether individual users should be consistently assigned the same
+     * connection within a balancing group until they log out.
+     *
+     * @return
+     *     Whether individual users should be consistently assigned the same
+     *     connection within a balancing group until they log out.
+     */
+    public boolean isSessionAffinityEnabled() {
+        return getModel().isSessionAffinityEnabled();
+    }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -26,6 +26,7 @@
 
     "CONNECTION_GROUP_ATTRIBUTES" : {
 
+        "FIELD_HEADER_ENABLE_SESSION_AFFINITY"  : "Enable session affinity:",
         "FIELD_HEADER_MAX_CONNECTIONS"          : "Maximum number of connections:",
         "FIELD_HEADER_MAX_CONNECTIONS_PER_USER" : "Maximum number of connections per user:",
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -32,6 +32,8 @@ CREATE TABLE `guacamole_connection_group` (
   -- Concurrency limits
   `max_connections`          int(11),
   `max_connections_per_user` int(11),
+  `enable_session_affinity`  boolean NOT NULL DEFAULT 0,
+
 
   PRIMARY KEY (`connection_group_id`),
   UNIQUE KEY `connection_group_name_parent` (`connection_group_name`, `parent_id`),

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.10.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.10.sql
@@ -87,3 +87,10 @@ ALTER TABLE guacamole_connection_history
     FOREIGN KEY (connection_id)
     REFERENCES guacamole_connection (connection_id) ON DELETE SET NULL;
 
+--
+-- Add session affinity column
+--
+
+ALTER TABLE guacamole_connection_group
+    ADD COLUMN enable_session_affinity boolean NOT NULL DEFAULT 0;
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -25,13 +25,14 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.apache.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
-        <id     column="connection_group_id"      property="objectID"              jdbcType="INTEGER"/>
-        <result column="connection_group_name"    property="name"                  jdbcType="VARCHAR"/>
-        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
-        <result column="type"                     property="type"                  jdbcType="VARCHAR"
+        <id     column="connection_group_id"      property="objectID"               jdbcType="INTEGER"/>
+        <result column="connection_group_name"    property="name"                   jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"       jdbcType="INTEGER"/>
+        <result column="type"                     property="type"                   jdbcType="VARCHAR"
                 javaType="org.apache.guacamole.net.auth.ConnectionGroup$Type"/>
-        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
-        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
+        <result column="max_connections"          property="maxConnections"         jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser"  jdbcType="INTEGER"/>
+        <result column="enable_session_affinity"  property="sessionAffinityEnabled" jdbcType="BOOLEAN"/>
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -79,7 +80,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         WHERE connection_group_id IN
             <foreach collection="identifiers" item="identifier"
@@ -98,7 +100,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
         WHERE guacamole_connection_group.connection_group_id IN
@@ -120,7 +123,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=VARCHAR}</if>
@@ -144,14 +148,16 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=VARCHAR},
             #{object.type,jdbcType=VARCHAR},
             #{object.maxConnections,jdbcType=INTEGER},
-            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER},
+            #{object.sessionAffinityEnabled,jdbcType=BOOLEAN}
         )
 
     </insert>
@@ -163,7 +169,8 @@
             parent_id                = #{object.parentIdentifier,jdbcType=VARCHAR},
             type                     = #{object.type,jdbcType=VARCHAR},
             max_connections          = #{object.maxConnections,jdbcType=INTEGER},
-            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER},
+            enable_session_affinity  = #{object.sessionAffinityEnabled,jdbcType=BOOLEAN}
         WHERE connection_group_id = #{object.objectID,jdbcType=INTEGER}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE guacamole_connection_group (
   -- Concurrency limits
   max_connections          integer,
   max_connections_per_user integer,
+  enable_session_affinity  boolean NOT NULL DEFAULT FALSE,
 
   PRIMARY KEY (connection_group_id),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.10.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.10.sql
@@ -88,3 +88,10 @@ ALTER TABLE guacamole_connection_history
     FOREIGN KEY (connection_id)
     REFERENCES guacamole_connection (connection_id) ON DELETE SET NULL;
 
+--
+-- Add session affinity column
+--
+
+ALTER TABLE guacamole_connection_group
+    ADD COLUMN enable_session_affinity boolean NOT NULL DEFAULT FALSE;
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -25,13 +25,14 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.apache.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
-        <id     column="connection_group_id"      property="objectID"              jdbcType="INTEGER"/>
-        <result column="connection_group_name"    property="name"                  jdbcType="VARCHAR"/>
-        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
-        <result column="type"                     property="type"                  jdbcType="VARCHAR"
+        <id     column="connection_group_id"      property="objectID"               jdbcType="INTEGER"/>
+        <result column="connection_group_name"    property="name"                   jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"       jdbcType="INTEGER"/>
+        <result column="type"                     property="type"                   jdbcType="VARCHAR"
                 javaType="org.apache.guacamole.net.auth.ConnectionGroup$Type"/>
-        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
-        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
+        <result column="max_connections"          property="maxConnections"         jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser"  jdbcType="INTEGER"/>
+        <result column="enable_session_affinity"  property="sessionAffinityEnabled" jdbcType="BOOLEAN"/>
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -79,7 +80,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         WHERE connection_group_id IN
             <foreach collection="identifiers" item="identifier"
@@ -98,7 +100,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
         WHERE guacamole_connection_group.connection_group_id IN
@@ -120,7 +123,8 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         FROM guacamole_connection_group
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=INTEGER}::integer</if>
@@ -144,14 +148,16 @@
             parent_id,
             type,
             max_connections,
-            max_connections_per_user
+            max_connections_per_user,
+            enable_session_affinity
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=INTEGER}::integer,
             #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type,
             #{object.maxConnections,jdbcType=INTEGER},
-            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER},
+            #{object.sessionAffinityEnabled,jdbcType=BOOLEAN}
         )
 
     </insert>
@@ -163,7 +169,8 @@
             parent_id                = #{object.parentIdentifier,jdbcType=INTEGER}::integer,
             type                     = #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type,
             max_connections          = #{object.maxConnections,jdbcType=INTEGER},
-            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER},
+            enable_session_affinity  = #{object.sessionAffinityEnabled,jdbcType=BOOLEAN}
         WHERE connection_group_id = #{object.objectID,jdbcType=INTEGER}::integer
     </update>
 


### PR DESCRIPTION
This change adds a new connection group attribute which, if enabled, causes balancing groups to consistently route the same users to the same connections until those users log out.