### PR TITLE
GUACAMOLE-5: Fix regression introduced by recent refactor of the REST API

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
@@ -172,6 +172,11 @@ public class RESTExceptionWrapper implements MethodInterceptor {
 
             }
 
+            // Rethrow unchecked exceptions such that they are properly wrapped
+            catch (RuntimeException e) {
+                throw new GuacamoleException(e.getMessage(), e);
+            }
+
         }
 
         // Additional credentials are needed
@@ -267,17 +272,21 @@ public class RESTExceptionWrapper implements MethodInterceptor {
         // All other errors
         catch (GuacamoleException e) {
 
-            // Generate default message
+            // Log all reasonable details of exception
             String message = e.getMessage();
-            if (message == null)
-                message = "Unexpected server error.";
+            if (message != null)
+                logger.error("Unexpected internal error: {}", message);
+            else
+                logger.error("An internal error occurred, but did not contain "
+                           + "an error message. Enable debug-level logging for "
+                           + "details.");
 
-            // Ensure internal errors are logged at the debug level
+            // Ensure internal errors are fully logged at the debug level
             logger.debug("Unexpected exception in REST endpoint.", e);
 
             throw new APIException(
                 APIError.Type.INTERNAL_ERROR,
-                message
+                "Unexpected server error."
             );
 
         }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.rest.activeconnection;
+
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.net.auth.ActiveConnection;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
+import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
+import org.apache.guacamole.rest.directory.DirectoryResource;
+
+/**
+ * A REST resource which abstracts the operations available on a Directory of
+ * ActiveConnections.
+ *
+ * @author Michael Jumper
+ */
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ActiveConnectionDirectoryResource
+        extends DirectoryResource<ActiveConnection, APIActiveConnection> {
+
+    /**
+     * Creates a new ActiveConnectionDirectoryResource which exposes the
+     * operations and subresources available for the given ActiveConnection
+     * Directory.
+     *
+     * @param userContext
+     *     The UserContext associated with the given Directory.
+     *
+     * @param directory
+     *     The Directory being exposed.
+     *
+     * @param translator
+     *     A DirectoryObjectTranslator implementation which handles
+     *     ActiveConnections.
+     *
+     * @param resourceFactory
+     *     A factory which can be used to create instances of resources
+     *     representing ActiveConnections.
+     */
+    @AssistedInject
+    public ActiveConnectionDirectoryResource(@Assisted UserContext userContext,
+            @Assisted Directory<ActiveConnection> directory,
+            DirectoryObjectTranslator<ActiveConnection, APIActiveConnection> translator,
+            DirectoryObjectResourceFactory<ActiveConnection, APIActiveConnection> resourceFactory) {
+        super(userContext, directory, translator, resourceFactory);
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionModule.java
@@ -27,6 +27,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.rest.directory.DirectoryObjectResource;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
+import org.apache.guacamole.rest.directory.DirectoryResource;
 
 /**
  * Guice Module which configures injections required for handling
@@ -41,6 +42,10 @@ public class ActiveConnectionModule extends AbstractModule {
 
         // Create the required DirectoryResourceFactory implementation
         install(new FactoryModuleBuilder()
+                .implement(
+                    new TypeLiteral<DirectoryResource<ActiveConnection, APIActiveConnection>>() {},
+                    ActiveConnectionDirectoryResource.class
+                )
                 .build(new TypeLiteral<DirectoryResourceFactory<ActiveConnection, APIActiveConnection>>() {}));
 
         // Create the required DirectoryObjectResourceFactory implementation

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.rest.connection;
+
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.net.auth.Connection;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
+import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
+import org.apache.guacamole.rest.directory.DirectoryResource;
+
+/**
+ * A REST resource which abstracts the operations available on a Directory of
+ * Connections.
+ *
+ * @author Michael Jumper
+ */
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ConnectionDirectoryResource
+        extends DirectoryResource<Connection, APIConnection> {
+
+    /**
+     * Creates a new ConnectionDirectoryResource which exposes the operations
+     * and subresources available for the given Connection Directory.
+     *
+     * @param userContext
+     *     The UserContext associated with the given Directory.
+     *
+     * @param directory
+     *     The Directory being exposed.
+     *
+     * @param translator
+     *     A DirectoryObjectTranslator implementation which handles
+     *     Connections.
+     *
+     * @param resourceFactory
+     *     A factory which can be used to create instances of resources
+     *     representing Connections.
+     */
+    @AssistedInject
+    public ConnectionDirectoryResource(@Assisted UserContext userContext,
+            @Assisted Directory<Connection> directory,
+            DirectoryObjectTranslator<Connection, APIConnection> translator,
+            DirectoryObjectResourceFactory<Connection, APIConnection> resourceFactory) {
+        super(userContext, directory, translator, resourceFactory);
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionModule.java
@@ -27,6 +27,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
+import org.apache.guacamole.rest.directory.DirectoryResource;
 
 /**
  * Guice Module which configures injections required for handling Connection
@@ -41,6 +42,10 @@ public class ConnectionModule extends AbstractModule {
 
         // Create the required DirectoryResourceFactory implementation
         install(new FactoryModuleBuilder()
+                .implement(
+                    new TypeLiteral<DirectoryResource<Connection, APIConnection>>() {},
+                    ConnectionDirectoryResource.class
+                )
                 .build(new TypeLiteral<DirectoryResourceFactory<Connection, APIConnection>>() {}));
 
         // Create the required DirectoryObjectResourceFactory implementation

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectResource.java
@@ -19,8 +19,6 @@
 
 package org.apache.guacamole.rest.directory;
 
-import com.google.inject.assistedinject.Assisted;
-import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -51,7 +49,7 @@ import org.apache.guacamole.net.auth.Identifiable;
  */
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class DirectoryObjectResource<InternalType extends Identifiable, ExternalType> {
+public abstract class DirectoryObjectResource<InternalType extends Identifiable, ExternalType> {
 
     /**
      * The Directory which contains the object represented by this
@@ -84,9 +82,7 @@ public class DirectoryObjectResource<InternalType extends Identifiable, External
      *     A DirectoryObjectTranslator implementation which handles the type of
      *     object given.
      */
-    @AssistedInject
-    public DirectoryObjectResource(@Assisted Directory<InternalType> directory,
-            @Assisted InternalType object,
+    public DirectoryObjectResource(Directory<InternalType> directory, InternalType object,
             DirectoryObjectTranslator<InternalType, ExternalType> translator) {
         this.directory = directory;
         this.object = object;

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
@@ -19,8 +19,6 @@
 
 package org.apache.guacamole.rest.directory;
 
-import com.google.inject.assistedinject.Assisted;
-import com.google.inject.assistedinject.AssistedInject;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -69,7 +67,7 @@ import org.apache.guacamole.rest.PATCH;
  */
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class DirectoryResource<InternalType extends Identifiable, ExternalType> {
+public abstract class DirectoryResource<InternalType extends Identifiable, ExternalType> {
 
     /**
      * The UserContext associated with the Directory being exposed by this
@@ -113,9 +111,7 @@ public class DirectoryResource<InternalType extends Identifiable, ExternalType> 
      *     A factory which can be used to create instances of resources
      *     representing individual objects contained within the given Directory.
      */
-    @AssistedInject
-    public DirectoryResource(@Assisted UserContext userContext,
-            @Assisted Directory<InternalType> directory,
+    public DirectoryResource(UserContext userContext, Directory<InternalType> directory,
             DirectoryObjectTranslator<InternalType, ExternalType> translator,
             DirectoryObjectResourceFactory<InternalType, ExternalType> resourceFactory) {
         this.userContext = userContext;


### PR DESCRIPTION
The recent refactor caused issues where actual type-specific implementations were not provided for the REST resources. All REST resources **MUST** be non-generic, thus `DirectoryResource` and `DirectoryObjectResource` **MUST NOT** be used directly. Type parameters of generic classes will otherwise be handled by Jersey as `Object` due to type erasure, resulting in class cast exceptions due to received JSON being deserialized as a `Map` instead of the intended type.

This change also updates the logging and error handling within `RESTExceptionWrapper` such that this sort of thing will be easier to notice going forward. Internal errors were not being properly logged, especially those which were not subclasses of `GuacamoleException`.