### PR TITLE
GUACAMOLE-5: Move common equals() / hashCode() of Identifiable implementations to base class

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractActiveConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractActiveConnection.java
@@ -22,12 +22,14 @@ package org.apache.guacamole.net.auth;
 import java.util.Date;
 import org.apache.guacamole.net.GuacamoleTunnel;
 
-public abstract class AbstractActiveConnection implements ActiveConnection {
-
-    /**
-     * The identifier of this active connection.
-     */
-    private String identifier;
+/**
+ * Base implementation of an ActiveConnection, providing storage and simply
+ * getters/setters for its main properties.
+ *
+ * @author Michael Jumper
+ */
+public abstract class AbstractActiveConnection extends AbstractIdentifiable
+        implements ActiveConnection {
 
     /**
      * The identifier of the associated connection.
@@ -54,16 +56,6 @@ public abstract class AbstractActiveConnection implements ActiveConnection {
      */
     private GuacamoleTunnel tunnel;
 
-    @Override
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
- 
     @Override
     public String getConnectionIdentifier() {
         return connectionIdentifier;

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -26,45 +26,9 @@ package org.apache.guacamole.net.auth;
  *
  * @author Michael Jumper
  */
-public abstract class AbstractAuthenticatedUser implements AuthenticatedUser {
+public abstract class AbstractAuthenticatedUser extends AbstractIdentifiable
+        implements AuthenticatedUser {
 
-    /**
-     * The name of this user.
-     */
-    private String username;
-
-    @Override
-    public String getIdentifier() {
-        return username;
-    }
-
-    @Override
-    public void setIdentifier(String username) {
-        this.username = username;
-    }
-
-    @Override
-    public int hashCode() {
-        if (username == null) return 0;
-        return username.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-
-        // Not equal if null or not a User
-        if (obj == null) return false;
-        if (!(obj instanceof AbstractAuthenticatedUser)) return false;
-
-        // Get username
-        String objUsername = ((AbstractAuthenticatedUser) obj).username;
-
-        // If null, equal only if this username is null
-        if (objUsername == null) return username == null;
-
-        // Otherwise, equal only if strings are identical
-        return objUsername.equals(username);
-
-    }
+    // Prior functionality now resides within AbstractIdentifiable
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractConnection.java
@@ -26,17 +26,14 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
  *
  * @author Michael Jumper
  */
-public abstract class AbstractConnection implements Connection {
+public abstract class AbstractConnection extends AbstractIdentifiable
+        implements Connection {
 
     /**
      * The name associated with this connection.
      */
     private String name;
 
-    /**
-     * The unique identifier associated with this connection.
-     */
-    private String identifier;
 
     /**
      * The unique identifier of the parent ConnectionGroup for
@@ -60,16 +57,6 @@ public abstract class AbstractConnection implements Connection {
     }
 
     @Override
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    @Override
     public String getParentIdentifier() {
         return parentIdentifier;
     }
@@ -87,30 +74,6 @@ public abstract class AbstractConnection implements Connection {
     @Override
     public void setConfiguration(GuacamoleConfiguration configuration) {
         this.configuration = configuration;
-    }
-
-    @Override
-    public int hashCode() {
-        if (identifier == null) return 0;
-        return identifier.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-
-        // Not equal if null or not a Connection
-        if (obj == null) return false;
-        if (!(obj instanceof AbstractConnection)) return false;
-
-        // Get identifier
-        String objIdentifier = ((AbstractConnection) obj).identifier;
-
-        // If null, equal only if this identifier is null
-        if (objIdentifier == null) return identifier == null;
-
-        // Otherwise, equal only if strings are identical
-        return objIdentifier.equals(identifier);
-
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractConnectionGroup.java
@@ -24,17 +24,13 @@ package org.apache.guacamole.net.auth;
  *
  * @author James Muehlner
  */
-public abstract class AbstractConnectionGroup implements ConnectionGroup {
+public abstract class AbstractConnectionGroup extends AbstractIdentifiable
+        implements ConnectionGroup {
 
     /**
      * The name associated with this connection group.
      */
     private String name;
-
-    /**
-     * The unique identifier associated with this connection group.
-     */
-    private String identifier;
 
     /**
      * The unique identifier of the parent connection group for
@@ -58,16 +54,6 @@ public abstract class AbstractConnectionGroup implements ConnectionGroup {
     }
 
     @Override
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public void setIdentifier(String identifier) {
-        this.identifier = identifier;
-    }
-
-    @Override
     public String getParentIdentifier() {
         return parentIdentifier;
     }
@@ -85,30 +71,6 @@ public abstract class AbstractConnectionGroup implements ConnectionGroup {
     @Override
     public void setType(ConnectionGroup.Type type) {
         this.type = type;
-    }
-
-    @Override
-    public int hashCode() {
-        if (identifier == null) return 0;
-        return identifier.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-
-        // Not equal if null or not a ConnectionGroup
-        if (obj == null) return false;
-        if (!(obj instanceof AbstractConnectionGroup)) return false;
-
-        // Get identifier
-        String objIdentifier = ((AbstractConnectionGroup) obj).identifier;
-
-        // If null, equal only if this identifier is null
-        if (objIdentifier == null) return identifier == null;
-
-        // Otherwise, equal only if strings are identical
-        return objIdentifier.equals(identifier);
-
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractIdentifiable.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractIdentifiable.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+
+/**
+ * Abstract implementation of Identifiable which provides equals() and
+ * hashCode() implementations which use the identifier to determine equality.
+ * The identifier comparison is case-sensitive.
+ *
+ * @author Michael Jumper
+ */
+public abstract class AbstractIdentifiable implements Identifiable {
+
+    /**
+     * The unique string which identifies this object.
+     */
+    private String identifier;
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public int hashCode() {
+
+        if (identifier == null)
+            return 0;
+
+        return identifier.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+
+        // Not equal if null or not the same type of object
+        if (other == null || getClass() != other.getClass())
+            return false;
+
+        // Get identifier of other object
+        String otherIdentifier = ((AbstractIdentifiable) other).getIdentifier();
+
+        // If null, equal only if this identifier is null
+        if (otherIdentifier == null)
+            return identifier == null;
+
+        // Otherwise, equal only if strings are identical
+        return otherIdentifier.equals(identifier);
+
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUser.java
@@ -26,12 +26,8 @@ package org.apache.guacamole.net.auth;
  *
  * @author Michael Jumper
  */
-public abstract class AbstractUser implements User {
-
-    /**
-     * The name of this user.
-     */
-    private String username;
+public abstract class AbstractUser extends AbstractIdentifiable
+        implements User {
 
     /**
      * This user's password. Note that while this provides a means for the
@@ -41,16 +37,6 @@ public abstract class AbstractUser implements User {
     private String password;
 
     @Override
-    public String getIdentifier() {
-        return username;
-    }
-
-    @Override
-    public void setIdentifier(String username) {
-        this.username = username;
-    }
-
-    @Override
     public String getPassword() {
         return password;
     }
@@ -58,30 +44,6 @@ public abstract class AbstractUser implements User {
     @Override
     public void setPassword(String password) {
         this.password = password;
-    }
-
-    @Override
-    public int hashCode() {
-        if (username == null) return 0;
-        return username.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-
-        // Not equal if null or not a User
-        if (obj == null) return false;
-        if (!(obj instanceof AbstractUser)) return false;
-
-        // Get username
-        String objUsername = ((AbstractUser) obj).username;
-
-        // If null, equal only if this username is null
-        if (objUsername == null) return username == null;
-
-        // Otherwise, equal only if strings are identical
-        return objUsername.equals(username);
-
     }
 
 }


### PR DESCRIPTION
To make developers lives easier, including my own, this change moves the common `equals()` and `hashCode()` of the `Identifiable` implementations used throughout the Guacamole API to a common base class: `AbstractIdentifiable`.

The logic is identical to all past version of Guacamole. The code in question is simply no longer duplicated.