### PR TITLE
GUACAMOLE-5: Implement connection sharing within database auth

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
@@ -63,8 +63,10 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionParameterMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionService;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionSet;
+import org.apache.guacamole.auth.jdbc.sharing.HashSharedConnectionMap;
 import org.apache.guacamole.auth.jdbc.sharing.SecureRandomShareKeyGenerator;
 import org.apache.guacamole.auth.jdbc.sharing.ShareKeyGenerator;
+import org.apache.guacamole.auth.jdbc.sharing.SharedConnectionMap;
 import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileDirectory;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileMapper;
@@ -170,6 +172,7 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
         bind(GuacamoleTunnelService.class).to(RestrictedGuacamoleTunnelService.class);
         bind(PasswordEncryptionService.class).to(SHA256PasswordEncryptionService.class);
         bind(SaltService.class).to(SecureRandomSaltService.class);
+        bind(SharedConnectionMap.class).to(HashSharedConnectionMap.class).in(Scopes.SINGLETON);
         bind(ShareKeyGenerator.class).to(SecureRandomShareKeyGenerator.class).in(Scopes.SINGLETON);
         bind(SharingProfilePermissionService.class);
         bind(SharingProfileService.class);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc;
 
+import com.google.inject.Scopes;
 import org.apache.guacamole.auth.jdbc.user.UserContext;
 import org.apache.guacamole.auth.jdbc.connectiongroup.RootConnectionGroup;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
@@ -62,6 +63,8 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionParameterMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionService;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionSet;
+import org.apache.guacamole.auth.jdbc.sharing.SecureRandomShareKeyGenerator;
+import org.apache.guacamole.auth.jdbc.sharing.ShareKeyGenerator;
 import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileDirectory;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileMapper;
@@ -167,6 +170,7 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
         bind(GuacamoleTunnelService.class).to(RestrictedGuacamoleTunnelService.class);
         bind(PasswordEncryptionService.class).to(SHA256PasswordEncryptionService.class);
         bind(SaltService.class).to(SecureRandomSaltService.class);
+        bind(ShareKeyGenerator.class).to(SecureRandomShareKeyGenerator.class).in(Scopes.SINGLETON);
         bind(SharingProfilePermissionService.class);
         bind(SharingProfileService.class);
         bind(SystemPermissionService.class);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
@@ -63,6 +63,7 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionParameterMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionService;
 import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionSet;
+import org.apache.guacamole.auth.jdbc.sharing.ConnectionSharingService;
 import org.apache.guacamole.auth.jdbc.sharing.HashSharedConnectionMap;
 import org.apache.guacamole.auth.jdbc.sharing.SecureRandomShareKeyGenerator;
 import org.apache.guacamole.auth.jdbc.sharing.ShareKeyGenerator;
@@ -168,6 +169,7 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
         bind(ConnectionGroupPermissionService.class);
         bind(ConnectionGroupService.class);
         bind(ConnectionPermissionService.class);
+        bind(ConnectionSharingService.class);
         bind(ConnectionService.class);
         bind(GuacamoleTunnelService.class).to(RestrictedGuacamoleTunnelService.class);
         bind(PasswordEncryptionService.class).to(SHA256PasswordEncryptionService.class);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
@@ -76,6 +76,13 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
     private String username;
 
     /**
+     * The connection ID of the connection as determined by guacd, not to be
+     * confused with the connection identifier determined by the database. This
+     * is the ID that must be supplied to guacd if joining this connection.
+     */
+    private String connectionID;
+
+    /**
      * The underlying GuacamoleTunnel.
      */
     private GuacamoleTunnel tunnel;
@@ -107,6 +114,7 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
         
         // Copy all non-sensitive data from given record
         this.connection               = activeConnectionRecord.getConnection();
+        this.connectionID             = activeConnectionRecord.getConnectionID();
         this.sharingProfileIdentifier = activeConnectionRecord.getSharingProfileIdentifier();
         this.identifier               = activeConnectionRecord.getUUID().toString();
         this.startDate                = activeConnectionRecord.getStartDate();
@@ -140,6 +148,19 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
      */
     public ModeledConnection getConnection() {
         return connection;
+    }
+
+    /**
+     * Returns the connection ID of the in-progress connection as determined by
+     * guacd, not to be confused with the connection identifier determined by
+     * the database. This is the ID that must be supplied to guacd if joining
+     * this connection.
+     *
+     * @return
+     *     The ID of the in-progress connection, as determined by guacd.
+     */
+    public String getConnectionID() {
+        return connectionID;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
 import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileService;
@@ -104,6 +105,12 @@ public class ConnectionSharingService {
         ModeledSharingProfile sharingProfile =
                 sharingProfileService.retrieveObject(user,
                         sharingProfileIdentifier);
+
+        // Verify that this profile is indeed a sharing profile for the
+        // requested connection
+        String connectionIdentifier = activeConnection.getConnectionIdentifier();
+        if (sharingProfile == null || !sharingProfile.getPrimaryConnectionIdentifier().equals(connectionIdentifier))
+            throw new GuacamoleSecurityException("Permission denied.");
 
         // Generate a share key for the requested connection
         String key = keyGenerator.getShareKey();

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import com.google.inject.Inject;
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
+import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
+import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileService;
+import org.apache.guacamole.form.Field;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.UserCredentials;
+
+/**
+ * Service which provides convenience methods for sharing active connections.
+ *
+ * @author Michael Jumper
+ */
+public class ConnectionSharingService {
+
+    /**
+     * The name of the query parameter that is used when authenticating obtain
+     * temporary access to a connection.
+     */
+    public static final String SHARE_KEY_NAME = "key";
+
+    /**
+     * Generator for sharing keys.
+     */
+    @Inject
+    private ShareKeyGenerator keyGenerator;
+
+    /**
+     * Map of all currently-shared connections.
+     */
+    @Inject
+    private SharedConnectionMap connectionMap;
+
+    /**
+     * Service for retrieving and manipulating sharing profile objects.
+     */
+    @Inject
+    private SharingProfileService sharingProfileService;
+
+    /**
+     * The credentials expected when a user is authenticating using temporary
+     * credentials in order to obtain access to a single connection.
+     */
+    public static final CredentialsInfo SHARE_KEY =
+            new CredentialsInfo(Collections.<Field>singletonList(
+                new Field(SHARE_KEY_NAME, Field.Type.QUERY_PARAMETER)
+            ));
+
+    /**
+     * Generates a set of temporary credentials which can be used to connect to
+     * the given connection using the given sharing profile. If the user does
+     * not have permission to share the connection via the given sharing
+     * profile, permission will be denied.
+     *
+     * @param user
+     *     The user sharing the connection.
+     *
+     * @param activeConnection
+     *     The active connection being shared.
+     *
+     * @param sharingProfileIdentifier
+     *     The identifier of the sharing profile dictating the semantics or
+     *     restrictions applying to the shared session.
+     *
+     * @return
+     *     A newly-generated set of temporary credentials which can be used to
+     *     connect to the given connection.
+     *
+     * @throws GuacamoleException
+     *     If permission to share the given connection is denied.
+     */
+    public UserCredentials generateTemporaryCredentials(AuthenticatedUser user,
+            TrackedActiveConnection activeConnection,
+            String sharingProfileIdentifier) throws GuacamoleException {
+
+        // Pull sharing profile (verifying access)
+        ModeledSharingProfile sharingProfile =
+                sharingProfileService.retrieveObject(user,
+                        sharingProfileIdentifier);
+
+        // Generate a share key for the requested connection
+        String key = keyGenerator.getShareKey();
+        connectionMap.put(key, new SharedConnectionDefinition(activeConnection,
+                sharingProfile));
+
+        // Return credentials defining a single expected parameter
+        return new UserCredentials(SHARE_KEY,
+                Collections.singletonMap(SHARE_KEY_NAME, key));
+
+    }
+
+    /**
+     * Returns a SharedConnectionUser (an implementation of AuthenticatedUser)
+     * if the given credentials contain a valid share key. The returned user
+     * will be associated with the single shared connection to which they have
+     * been granted temporary access. If the share key is invalid, or no share
+     * key is contained within the given credentials, null is returned.
+     *
+     * @param authProvider
+     *     The AuthenticationProvider on behalf of which the user is being
+     *     retrieved.
+     *
+     * @param credentials
+     *     The credentials which are expected to contain the share key.
+     *
+     * @return
+     *     A SharedConnectionUser with access to a single shared connection, if
+     *     the share key within the given credentials is valid, or null if the
+     *     share key is invalid or absent.
+     */
+    public SharedConnectionUser retrieveSharedConnectionUser(
+            AuthenticationProvider authProvider, Credentials credentials) {
+
+        // Pull associated HTTP request
+        HttpServletRequest request = credentials.getRequest();
+        if (request == null)
+            return null;
+
+        // Retrieve the share key from the request
+        String shareKey = request.getParameter(ConnectionSharingService.SHARE_KEY_NAME);
+        if (shareKey == null)
+            return null;
+
+        // Pull the connection definition describing the connection these
+        // credentials provide access to (if any)
+        SharedConnectionDefinition definition = connectionMap.get(shareKey);
+        if (definition == null)
+            return null;
+
+        // Return temporary in-memory user with access only to the shared connection
+        return new SharedConnectionUser(authProvider, definition, credentials);
+
+    }
+    
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/HashSharedConnectionMap.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/HashSharedConnectionMap.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A HashMap-based implementation of the SharedConnectionMap.
+ *
+ * @author Michael Jumper
+ */
+public class HashSharedConnectionMap implements SharedConnectionMap {
+
+    /**
+     * Keeps track of the share key to SharedConnectionDefinition mapping.
+     */
+    private final ConcurrentMap<String, SharedConnectionDefinition> connectionMap =
+            new ConcurrentHashMap<String, SharedConnectionDefinition>();
+
+    @Override
+    public SharedConnectionDefinition get(String key) {
+        
+        // There are no null share keys
+        if (key == null)
+            return null;
+
+        // Update the last access time and return the SharedConnectionDefinition
+        return connectionMap.get(key);
+
+    }
+
+    @Override
+    public void put(String key, SharedConnectionDefinition definition) {
+        connectionMap.put(key, definition);
+    }
+
+    @Override
+    public SharedConnectionDefinition remove(String key) {
+
+        // There are no null share keys
+        if (key == null)
+            return null;
+
+        // Attempt to retrieve only if non-null
+        return connectionMap.remove(key);
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SecureRandomShareKeyGenerator.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SecureRandomShareKeyGenerator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import java.security.SecureRandom;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * An implementation of the ShareKeyGenerator which uses SecureRandom to
+ * generate cryptographically-secure random sharing keys.
+ * 
+ * @author Michael Jumper
+ */
+public class SecureRandomShareKeyGenerator implements ShareKeyGenerator {
+
+    /**
+     * Instance of SecureRandom for generating sharing keys.
+     */
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String getShareKey() {
+        byte[] bytes = new byte[33];
+        secureRandom.nextBytes(bytes);
+        return DatatypeConverter.printBase64Binary(bytes);
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ShareKeyGenerator.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ShareKeyGenerator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+/**
+ * Produces unique keys that can be safely used for the automatically-generated
+ * "sharing credentials" associated with a shared connection.
+ * 
+ * @author Michael Jumper
+ */
+public interface ShareKeyGenerator {
+    
+    /**
+     * Returns a new share key, guaranteed to be unique from all previously-
+     * returned share keys.
+     * 
+     * @return
+     *     The new share key.
+     */
+    public String getShareKey();
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnection.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleUnsupportedException;
+import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
+import org.apache.guacamole.auth.jdbc.connectiongroup.RootConnectionGroup;
+import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.net.auth.Connection;
+import org.apache.guacamole.net.auth.ConnectionRecord;
+import org.apache.guacamole.protocol.GuacamoleClientInformation;
+import org.apache.guacamole.protocol.GuacamoleConfiguration;
+
+/**
+ * A Connection which joins an active connection, limited by restrictions
+ * defined by a sharing profile.
+ *
+ * @author Michael Jumper
+ */
+public class SharedConnection implements Connection {
+
+    /**
+     * Randomly-generated unique identifier, guaranteeing this shared connection
+     * does not duplicate the identifying information of the underlying
+     * connection being shared.
+     */
+    private final String identifier = UUID.randomUUID().toString();
+
+    /**
+     * The user that successfully authenticated to obtain access to this
+     * SharedConnection.
+     */
+    private SharedConnectionUser user;
+
+    /**
+     * The active connection being shared.
+     */
+    private TrackedActiveConnection activeConnection;
+
+    /**
+     * The sharing profile which dictates the level of access provided to a user
+     * of the shared connection.
+     */
+    private ModeledSharingProfile sharingProfile;
+
+    /**
+     * Creates a new SharedConnection which can be used to join the connection
+     * described by the given SharedConnectionDefinition.
+     *
+     * @param user
+     *     The user that successfully authenticated to obtain access to this
+     *     SharedConnection.
+     *
+     * @param definition
+     *     The SharedConnectionDefinition dictating the connection being shared
+     *     and any associated restrictions.
+     */
+    public void init(SharedConnectionUser user, SharedConnectionDefinition definition) {
+        this.user = user;
+        this.activeConnection = definition.getActiveConnection();
+        this.sharingProfile = definition.getSharingProfile();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public void setIdentifier(String identifier) {
+        throw new UnsupportedOperationException("Shared connections are immutable.");
+    }
+
+    @Override
+    public String getName() {
+        return sharingProfile.getName();
+    }
+
+    @Override
+    public void setName(String name) {
+        throw new UnsupportedOperationException("Shared connections are immutable.");
+    }
+
+    @Override
+    public String getParentIdentifier() {
+        return RootConnectionGroup.IDENTIFIER;
+    }
+
+    @Override
+    public void setParentIdentifier(String parentIdentifier) {
+        throw new UnsupportedOperationException("Shared connections are immutable.");
+    }
+
+    @Override
+    public GuacamoleConfiguration getConfiguration() {
+        GuacamoleConfiguration config = new GuacamoleConfiguration();
+        config.setProtocol(activeConnection.getConnection().getConfiguration().getProtocol());
+        return config;
+    }
+
+    @Override
+    public void setConfiguration(GuacamoleConfiguration config) {
+        throw new UnsupportedOperationException("Shared connections are immutable.");
+    }
+
+    @Override
+    public GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+        // STUB
+        throw new GuacamoleUnsupportedException("Connecting to shared connections is not yet implemented.");
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+        return Collections.<String, String>emptyMap();
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        // Do nothing - no attributes supported
+    }
+
+    @Override
+    public List<? extends ConnectionRecord> getHistory()
+            throws GuacamoleException {
+        return Collections.<ConnectionRecord>emptyList();
+    }
+
+    @Override
+    public Set<String> getSharingProfileIdentifiers()
+            throws GuacamoleException {
+        return Collections.<String>emptySet();
+    }
+
+    @Override
+    public int getActiveConnections() {
+        return 0;
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnection.java
@@ -19,16 +19,17 @@
 
 package org.apache.guacamole.auth.jdbc.sharing;
 
+import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.GuacamoleUnsupportedException;
 import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
 import org.apache.guacamole.auth.jdbc.connectiongroup.RootConnectionGroup;
 import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
+import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionRecord;
@@ -42,6 +43,12 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
  * @author Michael Jumper
  */
 public class SharedConnection implements Connection {
+
+    /**
+     * Service for establishing tunnels to Guacamole connections.
+     */
+    @Inject
+    private GuacamoleTunnelService tunnelService;
 
     /**
      * Randomly-generated unique identifier, guaranteeing this shared connection
@@ -130,8 +137,8 @@ public class SharedConnection implements Connection {
     @Override
     public GuacamoleTunnel connect(GuacamoleClientInformation info)
             throws GuacamoleException {
-        // STUB
-        throw new GuacamoleUnsupportedException("Connecting to shared connections is not yet implemented.");
+        return tunnelService.getGuacamoleTunnel(user, activeConnection,
+                sharingProfile, info);
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionDefinition.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionDefinition.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
+import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
+
+/**
+ * Defines the semantics/restrictions of a shared connection by associating an
+ * active connection with a sharing profile. The sharing profile defines the
+ * access provided to users of the shared active connection through its
+ * connection parameters.
+ *
+ * @author Michael Jumper
+ */
+public class SharedConnectionDefinition {
+
+    /**
+     * The active connection being shared.
+     */
+    private final TrackedActiveConnection activeConnection;
+
+    /**
+     * The sharing profile which dictates the level of access provided to a user
+     * of the shared connection.
+     */
+    private final ModeledSharingProfile sharingProfile;
+
+    /**
+     * Creates a new SharedConnectionDefinition which describes an active
+     * connection that can be joined, including the restrictions dictated by a
+     * given sharing profile.
+     *
+     * @param activeConnection
+     *     The active connection being shared.
+     *
+     * @param sharingProfile
+     *     A sharing profile whose associated parameters dictate the level of
+     *     access provided to the shared connection.
+     */
+    public SharedConnectionDefinition(TrackedActiveConnection activeConnection,
+            ModeledSharingProfile sharingProfile) {
+        this.activeConnection = activeConnection;
+        this.sharingProfile = sharingProfile;
+    }
+
+    /**
+     * Returns the TrackedActiveConnection of the actual in-progress connection
+     * being shared.
+     *
+     * @return
+     *     The TrackedActiveConnection being shared.
+     */
+    public TrackedActiveConnection getActiveConnection() {
+        return activeConnection;
+    }
+
+    /**
+     * Returns the ModeledSharingProfile whose associated parameters dictate the
+     * level of access granted to users of the shared connection.
+     *
+     * @return
+     *     A ModeledSharingProfile whose associated parameters dictate the
+     *     level of access granted to users of the shared connection.
+     */
+    public ModeledSharingProfile getSharingProfile() {
+        return sharingProfile;
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionMap.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionMap.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+/**
+ * Represents a mapping between share keys and the Guacamole connection being
+ * shared.
+ * 
+ * @author Michael Jumper
+ */
+public interface SharedConnectionMap {
+
+    /**
+     * Associates the given share key with a SharedConnectionDefinition,
+     * allowing the connection it describes to be accessed by users having the
+     * share key.
+     *
+     * @param key
+     *     The share key to use to share the connection described by the given
+     *     SharedConnectionDefinition.
+     *
+     * @param definition
+     *     The SharedConnectionDefinition describing the connection being
+     *     shared via the given share key.
+     */
+    public void put(String key, SharedConnectionDefinition definition);
+
+    /**
+     * Retrieves the connection definition associated with the given share key.
+     * If no such share key exists, null is returned.
+     *
+     * @param key
+     *     The share key associated with the connection definition to be
+     *     returned.
+     *
+     * @return
+     *     The connection definition associated with the given share key, or
+     *     null if no such share key exists.
+     */
+    public SharedConnectionDefinition get(String key);
+
+    /**
+     * Invalidates given share key, if it exists, returning the connection
+     * definition previously associated with that key. If no such share key
+     * exists, this function has no effect, and null is returned.
+     *
+     * @param key
+     *     The share key associated with the connection definition to be
+     *     removed.
+     *
+     * @return
+     *     The connection definition previously associated with the given
+     *     share key, or null if no such share key exists and no connection was
+     *     removed.
+     */
+    public SharedConnectionDefinition remove(String key);
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUser.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import java.util.UUID;
+import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+
+/**
+ * A temporary user who has authenticated using a share key and thus has
+ * restricted access to a single shared connection.
+ *
+ * @author Michael Jumper
+ */
+public class SharedConnectionUser extends RemoteAuthenticatedUser {
+
+    /**
+     * The single shared connection to which this user has access.
+     */
+    private final SharedConnectionDefinition definition;
+
+    /**
+     * An arbitrary identifier guaranteed to be unique across users. Note that
+     * because Guacamole users the AuthenticatedUser's identifier as the means
+     * of determining overall user identity and aggregating data across
+     * multiple extensions, this identifier MUST NOT match the identifier of
+     * any possibly existing user (or else the user may unexpectedly gain
+     * access to another identically-named user's data).
+     */
+    private final String identifier = UUID.randomUUID().toString();
+
+    /**
+     * Creates a new SharedConnectionUser with access solely to connection
+     * described by the given SharedConnectionDefinition.
+     *
+     * @param authenticationProvider
+     *     The AuthenticationProvider that has authenticated the given user.
+     *
+     * @param definition
+     *     The SharedConnectionDefinition describing the connection that this
+     *     user should have access to, along with any associated restrictions.
+     *
+     * @param credentials 
+     *     The credentials given by the user when they authenticated.
+     */
+    public SharedConnectionUser(AuthenticationProvider authenticationProvider,
+           SharedConnectionDefinition definition, Credentials credentials) {
+        super(authenticationProvider, credentials);
+        this.definition = definition;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public void setIdentifier(String identifier) {
+        throw new UnsupportedOperationException("Shared connection users are immutable");
+    }
+
+    /**
+     * Returns the SharedConnectionDefinition which describes the connection
+     * that this user should have access to, along with any associated
+     * restrictions.
+     *
+     * @return
+     *     The SharedConnectionDefinition describing the connection that this
+     *     user should have access to, along with any associated restrictions.
+     */
+    public SharedConnectionDefinition getSharedConnectionDefinition() {
+        return definition;
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUserContext.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.form.Form;
+import org.apache.guacamole.net.auth.ActiveConnection;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Connection;
+import org.apache.guacamole.net.auth.ConnectionGroup;
+import org.apache.guacamole.net.auth.ConnectionRecordSet;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.SharingProfile;
+import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.simple.SimpleConnectionDirectory;
+import org.apache.guacamole.net.auth.simple.SimpleConnectionGroup;
+import org.apache.guacamole.net.auth.simple.SimpleConnectionGroupDirectory;
+import org.apache.guacamole.net.auth.simple.SimpleConnectionRecordSet;
+import org.apache.guacamole.net.auth.simple.SimpleDirectory;
+import org.apache.guacamole.net.auth.simple.SimpleUser;
+import org.apache.guacamole.net.auth.simple.SimpleUserDirectory;
+
+/**
+ * The user context of a SharedConnectionUser, providing access ONLY to the
+ * user themselves, the single SharedConnection associated with that user, and
+ * an internal root connection group containing only that single
+ * SharedConnection.
+ *
+ * @author Michael Jumper
+ */
+public class SharedConnectionUserContext implements UserContext {
+
+    /**
+     * Provider for retrieving SharedConnection instances.
+     */
+    @Inject
+    private Provider<SharedConnection> connectionProvider;
+
+    /**
+     * The AuthenticationProvider that created this SharedConnectionUserContext.
+     */
+    @Inject
+    private AuthenticationProvider authProvider;
+
+    /**
+     * The user whose level of access is represented by this user context.
+     */
+    private User self;
+
+    /**
+     * A directory of all connections visible to the user for whom this user
+     * context was created.
+     */
+    private Directory<Connection> connectionDirectory;
+
+    /**
+     * A directory of all connection groups visible to the user for whom this
+     * user context was created.
+     */
+    private Directory<ConnectionGroup> connectionGroupDirectory;
+
+    /**
+     * A directory of all users visible to the user for whom this user context
+     * was created.
+     */
+    private Directory<User> userDirectory;
+
+    /**
+     * The root connection group of the hierarchy containing all connections
+     * and connection groups visible to the user for whom this user context was
+     * created.
+     */
+    private ConnectionGroup rootGroup;
+
+    /**
+     * Creates a new SharedConnectionUserContext which provides access ONLY to
+     * the given user, the single SharedConnection associated with that user,
+     * and an internal root connection group containing only that single
+     * SharedConnection.
+     *
+     * @param user
+     *     The SharedConnectionUser for whom this SharedConnectionUserContext
+     *     is being created.
+     */
+    public void init(SharedConnectionUser user) {
+
+        // Get the definition of the shared connection
+        SharedConnectionDefinition definition =
+                user.getSharedConnectionDefinition();
+
+        // Create a single shared connection accessible by the user
+        SharedConnection connection = connectionProvider.get();
+        connection.init(user, definition);
+
+        // Build list of all accessible connection identifiers
+        Collection<String> connectionIdentifiers =
+                Collections.singletonList(connection.getIdentifier());
+
+        // The connection directory should contain only the shared connection
+        this.connectionDirectory = new SimpleConnectionDirectory(
+                Collections.<Connection>singletonList(connection));
+
+        // The user should have access only to the shared connection and himself
+        this.self = new SimpleUser(user.getIdentifier(),
+                Collections.<String>singletonList(user.getIdentifier()),
+                connectionIdentifiers,
+                Collections.<String>emptyList());
+
+        // The root group contains only the shared connection
+        String rootIdentifier = connection.getParentIdentifier();
+        this.rootGroup = new SimpleConnectionGroup(rootIdentifier, rootIdentifier,
+                connectionIdentifiers, Collections.<String>emptyList());
+
+        // The connection group directory contains only the root group
+        this.connectionGroupDirectory = new SimpleConnectionGroupDirectory(
+                Collections.singletonList(this.rootGroup));
+
+        // The user directory contains only this user
+        this.userDirectory = new SimpleUserDirectory(this.self);
+
+    }
+
+    @Override
+    public User self() {
+        return self;
+    }
+
+    @Override
+    public AuthenticationProvider getAuthenticationProvider() {
+        return authProvider;
+    }
+
+    @Override
+    public Directory<User> getUserDirectory() {
+        return userDirectory;
+    }
+
+    @Override
+    public Directory<Connection> getConnectionDirectory()
+            throws GuacamoleException {
+        return connectionDirectory;
+    }
+
+    @Override
+    public Directory<ConnectionGroup> getConnectionGroupDirectory() {
+        return connectionGroupDirectory;
+    }
+
+    @Override
+    public Directory<ActiveConnection> getActiveConnectionDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<ActiveConnection>();
+    }
+
+    @Override
+    public Directory<SharingProfile> getSharingProfileDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<SharingProfile>();
+    }
+
+    @Override
+    public ConnectionRecordSet getConnectionHistory() {
+        return new SimpleConnectionRecordSet();
+    }
+
+    @Override
+    public ConnectionGroup getRootConnectionGroup() {
+        return rootGroup;
+    }
+
+    @Override
+    public Collection<Form> getUserAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getConnectionAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getConnectionGroupAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getSharingProfileAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -467,7 +467,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
 
                 // Verify that the connection ID is known
                 String connectionID = activeConnection.getConnectionID();
-                if (connectionID == null)
+                if (!activeConnection.isActive() || connectionID == null)
                     throw new GuacamoleResourceNotFoundException("No existing connection to be joined.");
 
                 // Build configuration from the sharing profile and the ID of

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
@@ -36,8 +36,7 @@ import org.apache.guacamole.protocol.ConfiguredGuacamoleSocket;
 /**
  * A connection record implementation that describes an active connection. As
  * the associated connection has not yet ended, getEndDate() will always return
- * null, and isActive() will always return true. The associated start date will
- * be the time of this objects creation.
+ * null. The associated start date will be the time of this objects creation.
  *
  * @author Michael Jumper
  */
@@ -325,10 +324,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
 
     @Override
     public boolean isActive() {
-
-        // Active connections are active by definition
-        return true;
-        
+        return tunnel != null && tunnel.isOpen();
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
@@ -24,6 +24,9 @@ import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.connection.ModeledConnection;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.activeconnection.TrackedActiveConnection;
+import org.apache.guacamole.auth.jdbc.sharing.SharedConnectionUser;
+import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
@@ -144,5 +147,40 @@ public interface GuacamoleTunnelService {
      *     currently-active connections.
      */
     public Collection<ActiveConnectionRecord> getActiveConnections(ConnectionGroup connectionGroup);
+
+    /**
+     * Creates a socket for the given user which joins the given active
+     * connection. The given client information will be passed to guacd when
+     * the connection is established. This function will apply any concurrent
+     * usage rules in effect, but will NOT test object- or system-level
+     * permissions.
+     *
+     * @param user
+     *     The user for whom the connection is being established.
+     *
+     * @param activeConnection
+     *     The active connection the user is joining.
+     *
+     * @param sharingProfile
+     *     The sharing profile whose associated parameters dictate the level
+     *     of access granted to the user joining the connection.
+     *
+     * @param info
+     *     Information describing the Guacamole client connecting to the given
+     *     connection.
+     *
+     * @return
+     *     A new GuacamoleTunnel which is configured and connected to the given
+     *     active connection.
+     *
+     * @throws GuacamoleException
+     *     If the connection cannot be established due to concurrent usage
+     *     rules.
+     */
+    GuacamoleTunnel getGuacamoleTunnel(SharedConnectionUser user,
+            TrackedActiveConnection activeConnection,
+            ModeledSharingProfile sharingProfile,
+            GuacamoleClientInformation info)
+            throws GuacamoleException;
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/RestrictedGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/RestrictedGuacamoleTunnelService.java
@@ -27,12 +27,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.guacamole.GuacamoleClientTooManyException;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.connection.ModeledConnection;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleResourceConflictException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
+import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
 
 
 /**
@@ -166,7 +166,7 @@ public class RestrictedGuacamoleTunnelService
     }
 
     @Override
-    protected ModeledConnection acquire(AuthenticatedUser user,
+    protected ModeledConnection acquire(RemoteAuthenticatedUser user,
             List<ModeledConnection> connections) throws GuacamoleException {
 
         // Do not acquire connection unless within overall limits
@@ -174,7 +174,7 @@ public class RestrictedGuacamoleTunnelService
             throw new GuacamoleResourceConflictException("Cannot connect. Overall maximum connections reached.");
 
         // Get username
-        String username = user.getUser().getIdentifier();
+        String username = user.getIdentifier();
 
         // Sort connections in ascending order of usage
         ModeledConnection[] sortedConnections = connections.toArray(new ModeledConnection[connections.size()]);
@@ -230,18 +230,18 @@ public class RestrictedGuacamoleTunnelService
     }
 
     @Override
-    protected void release(AuthenticatedUser user, ModeledConnection connection) {
-        activeSeats.remove(new Seat(user.getUser().getIdentifier(), connection.getIdentifier()));
+    protected void release(RemoteAuthenticatedUser user, ModeledConnection connection) {
+        activeSeats.remove(new Seat(user.getIdentifier(), connection.getIdentifier()));
         activeConnections.remove(connection.getIdentifier());
         totalActiveConnections.decrementAndGet();
     }
 
     @Override
-    protected void acquire(AuthenticatedUser user,
+    protected void acquire(RemoteAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup) throws GuacamoleException {
 
         // Get username
-        String username = user.getUser().getIdentifier();
+        String username = user.getIdentifier();
 
         // Attempt to aquire connection group according to per-user limits
         Seat seat = new Seat(username, connectionGroup.getIdentifier());
@@ -267,9 +267,9 @@ public class RestrictedGuacamoleTunnelService
     }
 
     @Override
-    protected void release(AuthenticatedUser user,
+    protected void release(RemoteAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup) {
-        activeGroupSeats.remove(new Seat(user.getUser().getIdentifier(), connectionGroup.getIdentifier()));
+        activeGroupSeats.remove(new Seat(user.getIdentifier(), connectionGroup.getIdentifier()));
         activeGroups.remove(connectionGroup.getIdentifier());
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/AuthenticatedUser.java
@@ -22,9 +22,6 @@ package org.apache.guacamole.auth.jdbc.user;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.servlet.http.HttpServletRequest;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 
@@ -33,48 +30,12 @@ import org.apache.guacamole.net.auth.Credentials;
  *
  * @author Michael Jumper 
  */
-public class AuthenticatedUser implements org.apache.guacamole.net.auth.AuthenticatedUser {
+public class AuthenticatedUser extends RemoteAuthenticatedUser {
 
     /**
      * The user that authenticated.
      */
     private final ModeledUser user;
-
-    /**
-     * The credentials given when this user authenticated.
-     */
-    private final Credentials credentials;
-
-    /**
-     * The AuthenticationProvider that authenticated this user.
-     */
-    private final AuthenticationProvider authenticationProvider;
-
-    /**
-     * The host from which this user authenticated.
-     */
-    private final String remoteHost;
-
-    /**
-     * Regular expression which matches any IPv4 address.
-     */
-    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
-
-    /**
-     * Regular expression which matches any IPv6 address.
-     */
-    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
-
-    /**
-     * Regular expression which matches any IP address, regardless of version.
-     */
-    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
-
-    /**
-     * Pattern which matches valid values of the de-facto standard
-     * "X-Forwarded-For" header.
-     */
-    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + "(, " + IP_ADDRESS_REGEX + ")*$");
 
     /**
      * The connections which have been committed for use by this user in the
@@ -87,38 +48,6 @@ public class AuthenticatedUser implements org.apache.guacamole.net.auth.Authenti
     private final Set<String> preferredConnections =
             Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
-    /**
-     * Derives the remote host of the authenticating user from the given
-     * credentials object. The remote host is derived from X-Forwarded-For
-     * in addition to the actual source IP of the request, and thus is not
-     * trusted. The derived remote host is really only useful for logging,
-     * unless the server is configured such that X-Forwarded-For is guaranteed
-     * to be trustworthy.
-     *
-     * @param credentials
-     *     The credentials to derive the remote host from.
-     *
-     * @return
-     *     The remote host from which the user with the given credentials is
-     *     authenticating.
-     */
-    private static String getRemoteHost(Credentials credentials) {
-
-        HttpServletRequest request = credentials.getRequest();
-
-        // Use X-Forwarded-For, if present and valid
-        String header = request.getHeader("X-Forwarded-For");
-        if (header != null) {
-            Matcher matcher = X_FORWARDED_FOR.matcher(header);
-            if (matcher.matches())
-                return matcher.group(1);
-        }
-
-        // If header absent or invalid, just use source IP
-        return request.getRemoteAddr();
-
-    }
-    
     /**
      * Creates a new AuthenticatedUser associating the given user with their
      * corresponding credentials.
@@ -134,10 +63,8 @@ public class AuthenticatedUser implements org.apache.guacamole.net.auth.Authenti
      */
     public AuthenticatedUser(AuthenticationProvider authenticationProvider,
             ModeledUser user, Credentials credentials) {
-        this.authenticationProvider = authenticationProvider;
+        super(authenticationProvider, credentials);
         this.user = user;
-        this.credentials = credentials;
-        this.remoteHost = getRemoteHost(credentials);
     }
 
     /**
@@ -148,27 +75,6 @@ public class AuthenticatedUser implements org.apache.guacamole.net.auth.Authenti
      */
     public ModeledUser getUser() {
         return user;
-    }
-
-    /**
-     * Returns the credentials given during authentication by this user.
-     *
-     * @return 
-     *     The credentials given during authentication by this user.
-     */
-    @Override
-    public Credentials getCredentials() {
-        return credentials;
-    }
-
-    /**
-     * Returns the host from which this user authenticated.
-     *
-     * @return
-     *     The host from which this user authenticated.
-     */
-    public String getRemoteHost() {
-        return remoteHost;
     }
 
     /**
@@ -199,11 +105,6 @@ public class AuthenticatedUser implements org.apache.guacamole.net.auth.Authenti
      */
     public void preferConnection(String identifier) {
         preferredConnections.add(identifier);
-    }
-
-    @Override
-    public AuthenticationProvider getAuthenticationProvider() {
-        return authenticationProvider;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.user;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+
+/**
+ * An AuthenticatedUser that has an associated remote host.
+ *
+ * @author Michael Jumper 
+ */
+public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
+
+    /**
+     * The credentials given when this user authenticated.
+     */
+    private final Credentials credentials;
+
+    /**
+     * The AuthenticationProvider that authenticated this user.
+     */
+    private final AuthenticationProvider authenticationProvider;
+
+    /**
+     * The host from which this user authenticated.
+     */
+    private final String remoteHost;
+
+    /**
+     * Regular expression which matches any IPv4 address.
+     */
+    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
+
+    /**
+     * Regular expression which matches any IPv6 address.
+     */
+    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
+
+    /**
+     * Regular expression which matches any IP address, regardless of version.
+     */
+    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
+
+    /**
+     * Pattern which matches valid values of the de-facto standard
+     * "X-Forwarded-For" header.
+     */
+    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + "(, " + IP_ADDRESS_REGEX + ")*$");
+
+    /**
+     * Derives the remote host of the authenticating user from the given
+     * credentials object. The remote host is derived from X-Forwarded-For
+     * in addition to the actual source IP of the request, and thus is not
+     * trusted. The derived remote host is really only useful for logging,
+     * unless the server is configured such that X-Forwarded-For is guaranteed
+     * to be trustworthy.
+     *
+     * @param credentials
+     *     The credentials to derive the remote host from.
+     *
+     * @return
+     *     The remote host from which the user with the given credentials is
+     *     authenticating.
+     */
+    private static String getRemoteHost(Credentials credentials) {
+
+        HttpServletRequest request = credentials.getRequest();
+
+        // Use X-Forwarded-For, if present and valid
+        String header = request.getHeader("X-Forwarded-For");
+        if (header != null) {
+            Matcher matcher = X_FORWARDED_FOR.matcher(header);
+            if (matcher.matches())
+                return matcher.group(1);
+        }
+
+        // If header absent or invalid, just use source IP
+        return request.getRemoteAddr();
+
+    }
+    
+    /**
+     * Creates a new RemoteAuthenticatedUser, deriving the associated remote
+     * host from the given credentials.
+     *
+     * @param authenticationProvider
+     *     The AuthenticationProvider that has authenticated the given user.
+     *
+     * @param credentials 
+     *     The credentials given by the user when they authenticated.
+     */
+    public RemoteAuthenticatedUser(AuthenticationProvider authenticationProvider,
+            Credentials credentials) {
+        this.authenticationProvider = authenticationProvider;
+        this.credentials = credentials;
+        this.remoteHost = getRemoteHost(credentials);
+    }
+
+    @Override
+    public Credentials getCredentials() {
+        return credentials;
+    }
+
+    /**
+     * Returns the host from which this user authenticated.
+     *
+     * @return
+     *     The host from which this user authenticated.
+     */
+    public String getRemoteHost() {
+        return remoteHost;
+    }
+
+    @Override
+    public AuthenticationProvider getAuthenticationProvider() {
+        return authenticationProvider;
+    }
+
+}


### PR DESCRIPTION
This change adds support for generation of temporary user credentials for shared connections.

The implementation produces sets of credentials which define only a single query parameter (`key`), which is accepted by the `AuthenticationProvider` and tied to a new `SharedConnectionUserContext`. The user context provides access only to a single connection which transparently joins the underlying existing connection, with the whole tree of data residing only in memory.