### PR TITLE
GUACAMOLE-5: Fix non-admin access to sharing profiles.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -80,6 +80,7 @@ public class ActiveConnectionService
     public Collection<TrackedActiveConnection> retrieveObjects(AuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
 
+        String username = user.getIdentifier();
         boolean isAdmin = user.getUser().isAdministrator();
         Set<String> identifierSet = new HashSet<String>(identifiers);
 
@@ -90,10 +91,15 @@ public class ActiveConnectionService
         Collection<TrackedActiveConnection> activeConnections = new ArrayList<TrackedActiveConnection>(identifiers.size());
         for (ActiveConnectionRecord record : records) {
 
+            // Sensitive information should be included if the connection was
+            // started by the current user OR the user is an admin
+            boolean includeSensitiveInformation =
+                    isAdmin || username.equals(record.getUsername());
+
             // Add connection if within requested identifiers
             if (identifierSet.contains(record.getUUID().toString())) {
                 TrackedActiveConnection activeConnection = trackedActiveConnectionProvider.get();
-                activeConnection.init(user, record, isAdmin);
+                activeConnection.init(user, record, includeSensitiveInformation);
                 activeConnections.add(activeConnection);
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -55,7 +55,7 @@
 
     <!-- Select identifiers of all readable sharing profiles associated with a particular connection -->
     <select id="selectReadableIdentifiersWithin" resultType="string">
-        SELECT sharing_profile_id
+        SELECT guacamole_sharing_profile.sharing_profile_id
         FROM guacamole_sharing_profile
         JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
         WHERE

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -55,7 +55,7 @@
 
     <!-- Select identifiers of all readable sharing profiles associated with a particular connection -->
     <select id="selectReadableIdentifiersWithin" resultType="string">
-        SELECT sharing_profile_id
+        SELECT guacamole_sharing_profile.sharing_profile_id
         FROM guacamole_sharing_profile
         JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
         WHERE

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.rest.activeconnection.APIActiveConnection;
@@ -96,10 +97,14 @@ public class TunnelResource {
         // Pull the UserContext from the tunnel
         UserContext userContext = tunnel.getUserContext();
 
+        // Fail if the active connection cannot be found
+        ActiveConnection activeConnection = tunnel.getActiveConnection();
+        if (activeConnection == null)
+            throw new GuacamoleResourceNotFoundException("No readable active connection for tunnel.");
+
         // Return the associated ActiveConnection as a resource
         return activeConnectionResourceFactory.create(userContext,
-                userContext.getActiveConnectionDirectory(),
-                tunnel.getActiveConnection());
+                userContext.getActiveConnectionDirectory(), activeConnection);
 
     }
 


### PR DESCRIPTION
This change fixes the following issues discovered after testing sharing profiles in a production environment against non-admin users:

1. The tunnel beneath an active connection was only being exposed to admin users, thus breaking the `.../api/session/tunnels/[UUID]/activeConnection` resource for non-admins. Users should be able to see the data associated with their own active connections.
2. As the above resource was written under the faulty assumption that the active connection can always be retrieved (what if the extension does not implement active connection tracking), a hard HTTP 500 was thrown when this assumption failed. The resource should instead throw a nice HTTP 404.
3. The permission-restricted query for retrieving the sharing profile identifiers associated with a particular connection was ambiguous with respect to the `sharing_profile_id` column, which occurs in both the `guacamole_sharing_profile` and `guacamole_sharing_profile_permission` tables.