### PR TITLE
GUACAMOLE-5 Fix syntax error in mysql create script by adding missing comma.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -327,7 +327,7 @@ CREATE TABLE `guacamole_connection_history` (
 
   CONSTRAINT `guacamole_connection_history_ibfk_2`
     FOREIGN KEY (`connection_id`)
-    REFERENCES `guacamole_connection` (`connection_id`) ON DELETE SET NULL
+    REFERENCES `guacamole_connection` (`connection_id`) ON DELETE SET NULL,
 
   CONSTRAINT `guacamole_connection_history_ibfk_3`
     FOREIGN KEY (`sharing_profile_id`)


### PR DESCRIPTION
We need to fix this to restore the mysql schema create script to working order.