### PR TITLE
GUACAMOLE-5: Remove need to bind/inject AuthenticationProvider

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
@@ -74,7 +74,6 @@ import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileMapper;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileParameterMapper;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileService;
 import org.apache.guacamole.auth.jdbc.tunnel.RestrictedGuacamoleTunnelService;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.mybatis.guice.MyBatisModule;
 import org.mybatis.guice.datasource.builtin.PooledDataSourceProvider;
 
@@ -94,26 +93,14 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
     private final JDBCEnvironment environment;
 
     /**
-     * The AuthenticationProvider which is using this module to configure
-     * injection.
-     */
-    private final AuthenticationProvider authProvider;
-
-    /**
      * Creates a new JDBC authentication provider module that configures the
      * various injected base classes using the given environment, and provides
      * connections using the given socket service.
      *
-     * @param authProvider
-     *     The AuthenticationProvider which is using this module to configure
-     *     injection.
-     *
      * @param environment
      *     The environment to use to configure injected classes.
      */
-    public JDBCAuthenticationProviderModule(AuthenticationProvider authProvider,
-            JDBCEnvironment environment) {
-        this.authProvider = authProvider;
+    public JDBCAuthenticationProviderModule(JDBCEnvironment environment) {
         this.environment = environment;
     }
 
@@ -143,7 +130,6 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
         // Bind core implementations of guacamole-ext classes
         bind(ActiveConnectionDirectory.class);
         bind(ActiveConnectionPermissionSet.class);
-        bind(AuthenticationProvider.class).toInstance(authProvider);
         bind(JDBCEnvironment.class).toInstance(environment);
         bind(ConnectionDirectory.class);
         bind(ConnectionGroupDirectory.class);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedConnectionUserContext.java
@@ -61,7 +61,6 @@ public class SharedConnectionUserContext implements UserContext {
     /**
      * The AuthenticationProvider that created this SharedConnectionUserContext.
      */
-    @Inject
     private AuthenticationProvider authProvider;
 
     /**
@@ -117,6 +116,9 @@ public class SharedConnectionUserContext implements UserContext {
         // Build list of all accessible connection identifiers
         Collection<String> connectionIdentifiers =
                 Collections.singletonList(connection.getIdentifier());
+
+        // Associate the originating authentication provider
+        this.authProvider = user.getAuthenticationProvider();
 
         // The connection directory should contain only the shared connection
         this.connectionDirectory = new SimpleConnectionDirectory(

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
@@ -54,12 +54,6 @@ public class UserContext extends RestrictedObject
     implements org.apache.guacamole.net.auth.UserContext {
 
     /**
-     * The AuthenticationProvider that created this UserContext.
-     */
-    @Inject
-    private AuthenticationProvider authProvider;
-
-    /**
      * User directory restricted by the permissions of the user associated
      * with this context.
      */
@@ -127,7 +121,7 @@ public class UserContext extends RestrictedObject
 
     @Override
     public AuthenticationProvider getAuthenticationProvider() {
-        return authProvider;
+        return getCurrentUser().getAuthenticationProvider();
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProvider.java
@@ -65,7 +65,7 @@ public class MySQLAuthenticationProvider implements AuthenticationProvider {
             new MySQLAuthenticationProviderModule(environment),
 
             // Configure JDBC authentication core
-            new JDBCAuthenticationProviderModule(this, environment)
+            new JDBCAuthenticationProviderModule(environment)
 
         );
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
@@ -26,7 +26,6 @@ import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderModule;
-import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.user.AuthenticationProviderService;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.slf4j.Logger;
@@ -73,7 +72,7 @@ public class PostgreSQLAuthenticationProvider implements AuthenticationProvider 
             new PostgreSQLAuthenticationProviderModule(environment),
 
             // Configure JDBC authentication core
-            new JDBCAuthenticationProviderModule(this, environment)
+            new JDBCAuthenticationProviderModule(environment)
 
         );
 


### PR DESCRIPTION
This change removes the need to inject `AuthenticationProvider` within the database auth backend. In contrast to my other PRs lately, it's mostly deletions.

### But why?

To allow multiple connection share keys to be used within a single session (producing a `UserContext` which contains the union of all shared connections provided by those keys), I need to move the sharing bits to their own `AuthenticationProvider` within the same extension.

This is possible, but will require that a common Guice injector is shared between those two auth providers. That is *also* possible, but will require that a common and reliable set of dependencies exist, ideally the *same* dependencies.

It turns out that the only dependency that would be different between the two is the `AuthenticationProvider` itself, which is only injected in one place anyway: the `UserContext` implementations. Removing that need makes the rest of this easier.

Even if the above approach doesn't work out, however, I still think this should be done. It's cleaner, and it seems like injecting `AuthenticationProvider` was unnecessary in the first place.
