### PR TITLE
GUACAMOLE-66: Remove Apache Commons Codec dependency.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -324,13 +324,6 @@
             <version>1.0</version>
         </dependency>
         
-        <!-- Apache commons codec library -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
-        </dependency>
-        
         <!-- Jackson for JSON support -->
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/SecureRandomAuthTokenGenerator.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/SecureRandomAuthTokenGenerator.java
@@ -20,7 +20,7 @@
 package org.apache.guacamole.rest.auth;
 
 import java.security.SecureRandom;
-import org.apache.commons.codec.binary.Hex;
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * An implementation of the AuthTokenGenerator based around SecureRandom.
@@ -39,7 +39,7 @@ public class SecureRandomAuthTokenGenerator implements AuthTokenGenerator {
         byte[] bytes = new byte[32];
         secureRandom.nextBytes(bytes);
         
-        return Hex.encodeHexString(bytes);
+        return DatatypeConverter.printHexBinary(bytes);
     }
     
 }


### PR DESCRIPTION
We already have a standard way of converting a byte array to a hex string, so let's just use that instead.