### PR TITLE
GUACAMOLE-5: Properly validate identifiers before attempting to query.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import javax.xml.stream.events.Characters;
 import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -311,6 +312,9 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     @Override
     public Collection<InternalType> retrieveObjects(AuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
+
+        // Ignore invalid identifiers
+        identifiers = ObjectModel.filterIdentifiers(identifiers);
 
         // Do not query if no identifiers given
         if (identifiers.isEmpty())

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ObjectModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ObjectModel.java
@@ -19,6 +19,9 @@
 
 package org.apache.guacamole.auth.jdbc.base;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 /**
  * Object representation of a Guacamole object, such as a user or connection,
  * as represented in the database.
@@ -82,6 +85,62 @@ public abstract class ObjectModel {
      */
     public void setObjectID(Integer objectID) {
         this.objectID = objectID;
+    }
+
+    /**
+     * Returns whether the given string is a valid identifier within the JDBC
+     * authentication extension. Invalid identifiers may result in SQL errors
+     * from the underlying database when used in queries.
+     *
+     * @param identifier
+     *     The string to check for validity.
+     *
+     * @return
+     *     true if the given string is a valid identifier, false otherwise.
+     */
+    public static boolean isValidIdentifier(String identifier) {
+
+        // Empty identifiers are invalid
+        if (identifier.isEmpty())
+            return false;
+
+        // Identifier is invalid if any non-numeric characters are present
+        for (int i = 0; i < identifier.length(); i++) {
+            if (!Character.isDigit(identifier.charAt(i)))
+                return false;
+        }
+
+        // Identifier is valid - contains only numeric characters
+        return true;
+
+    }
+
+    /**
+     * Filters the given collection of strings, returning a new collection
+     * containing only those strings which are valid identifiers. If no strings
+     * within the collection are valid identifiers, the returned collection will
+     * simply be empty.
+     *
+     * @param identifiers
+     *     The collection of strings to filter.
+     *
+     * @return
+     *     A new collection containing only the strings within the provided
+     *     collection which are valid identifiers.
+     */
+    public static Collection<String> filterIdentifiers(Collection<String> identifiers) {
+
+        // Obtain enough space for a full copy of the given identifiers
+        Collection<String> validIdentifiers = new ArrayList<String>(identifiers.size());
+
+        // Add only valid identifiers to the copy
+        for (String identifier : identifiers) {
+            if (ObjectModel.isValidIdentifier(identifier))
+                validIdentifiers.add(identifier);
+        }
+
+        return validIdentifiers;
+
     }
 
 }


### PR DESCRIPTION
Lacking such validation, attempts to go to invalid client URLs (such as stale URLs from a past shared connection) result in hard SQL errors if the backend database is PostgreSQL.