### PR TITLE
GUACAMOLE-5: Separate sharing semantics from database-backed AuthenticationProvider

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc;
+
+import com.google.inject.Injector;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.auth.jdbc.user.AuthenticationProviderService;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+
+/**
+ * Provides a base implementation of an AuthenticationProvider which is backed
+ * by an arbitrary underlying database. It is up to the subclass implementation
+ * to configure the underlying database appropriately via Guice.
+ *
+ * @author James Muehlner
+ * @author Michael Jumper
+ */
+public abstract class JDBCAuthenticationProvider implements AuthenticationProvider {
+
+    /**
+     * Provider of the singleton Injector instance which will manage the object
+     * graph of this authentication provider.
+     */
+    private final JDBCInjectorProvider injectorProvider;
+
+    /**
+     * Creates a new AuthenticationProvider that is backed by an arbitrary
+     * underlying database.
+     *
+     * @param injectorProvider
+     *     A JDBCInjectorProvider instance which provides singleton instances
+     *     of a Guice Injector, pre-configured to set up all injections and
+     *     access to the underlying database via MyBatis.
+     */
+    public JDBCAuthenticationProvider(JDBCInjectorProvider injectorProvider) {
+        this.injectorProvider = injectorProvider;
+    }
+
+    @Override
+    public AuthenticatedUser authenticateUser(Credentials credentials)
+            throws GuacamoleException {
+
+        Injector injector = injectorProvider.get();
+
+        // Create AuthenticatedUser based on credentials, if valid
+        AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
+        return authProviderService.authenticateUser(this, credentials);
+
+    }
+
+    @Override
+    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
+
+        // No need to update authenticated users
+        return authenticatedUser;
+
+    }
+
+    @Override
+    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
+            throws GuacamoleException {
+
+        Injector injector = injectorProvider.get();
+
+        // Create UserContext based on credentials, if valid
+        AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
+        return authProviderService.getUserContext(authenticatedUser);
+
+    }
+
+    @Override
+    public UserContext updateUserContext(UserContext context,
+            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+
+        // No need to update the context
+        return context;
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.user.ModeledUser;
+import org.apache.guacamole.auth.jdbc.user.UserContext;
+import org.apache.guacamole.auth.jdbc.user.UserService;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
+
+/**
+ * AuthenticationProviderService implementation which authenticates users with
+ * a username/password pair, producing new UserContext objects which are backed
+ * by an underlying, arbitrary database.
+ *
+ * @author Michael Jumper
+ */
+public class JDBCAuthenticationProviderService implements AuthenticationProviderService  {
+
+    /**
+     * Service for accessing users.
+     */
+    @Inject
+    private UserService userService;
+
+    /**
+     * Provider for retrieving UserContext instances.
+     */
+    @Inject
+    private Provider<UserContext> userContextProvider;
+
+    @Override
+    public AuthenticatedUser authenticateUser(AuthenticationProvider authenticationProvider,
+            Credentials credentials) throws GuacamoleException {
+
+        // Authenticate user
+        AuthenticatedUser user = userService.retrieveAuthenticatedUser(authenticationProvider, credentials);
+        if (user != null)
+            return user;
+
+        // Otherwise, unauthorized
+        throw new GuacamoleInvalidCredentialsException("Invalid login", CredentialsInfo.USERNAME_PASSWORD);
+
+    }
+
+    @Override
+    public org.apache.guacamole.net.auth.UserContext getUserContext(
+            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+
+        // Retrieve user account for already-authenticated user
+        ModeledUser user = userService.retrieveUser(authenticatedUser);
+        if (user == null)
+            return null;
+
+        // Link to user context
+        UserContext context = userContextProvider.get();
+        context.init(user.getCurrentUser());
+        return context;
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCInjectorProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCInjectorProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc;
+
+import com.google.inject.Injector;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * A caching provider of singleton Guice Injector instances. The first call to
+ * get() will return a new instance of the Guice Injector, while all subsequent
+ * calls will return that same instance. It is up to implementations of this
+ * class to define how the Guice Injector will be created through defining the
+ * create() function.
+ *
+ * IMPORTANT: Because the Injector returned by get() is cached statically, only
+ * ONE implementation of this class may be used within any individual
+ * classloader. Within the context of the JDBC extension, as long as each built
+ * extension only provides one subclass of this class, things should work
+ * properly, as each extension is given its own classloader by Guacamole.
+ *
+ * @author Michael Jumper
+ */
+public abstract class JDBCInjectorProvider {
+
+    /**
+     * An AtomicReference wrapping the cached Guice Injector. If the Injector
+     * has not yet been created, null will be wrapped instead.
+     */
+    private static final AtomicReference<Injector> injector = new AtomicReference<Injector>(null);
+
+    /**
+     * Creates a new instance of the Guice Injector which should be used
+     * across the entire JDBC authentication extension. This function will
+     * generally only be called once, but multiple invocations are possible if
+     * get() is invoked several times concurrently prior to the Injector being
+     * cached.
+     *
+     * @return
+     * @throws GuacamoleException
+     */
+    protected abstract Injector create() throws GuacamoleException;
+
+    /**
+     * Returns a common, singleton instance of a Guice Injector, configured for
+     * the injections required by the JDBC authentication extension. The result
+     * of the first call to this function will be cached statically within this
+     * class, and will be returned for all subsequent calls.
+     *
+     * @return
+     *     A singleton instance of the Guice Injector used across the entire
+     *     JDBC authentication extension.
+     *
+     * @throws GuacamoleException
+     *     If the Injector cannot be created due to an error.
+     */
+    public Injector get() throws GuacamoleException {
+
+        // Return existing Injector if already created
+        Injector value = injector.get();
+        if (value != null)
+            return value;
+
+        // Explicitly create and store new Injector only if necessary
+        injector.compareAndSet(null, create());
+
+        // Consistently return the same Injector, even if two create operations
+        // happen concurrently
+        return injector.get();
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedAuthenticationProviderService.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.sharing;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.AuthenticationProviderService;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
+
+/**
+ * Service which authenticates users based on share keys and provides for the
+ * creation of corresponding. The created UserContext objects are restricted to
+ * the connections associated with those share keys via a common
+ * ConnectionSharingService.
+ *
+ * @author Michael Jumper
+ */
+public class SharedAuthenticationProviderService implements AuthenticationProviderService {
+
+    /**
+     * Provider for retrieving SharedConnectionUserContext instances.
+     */
+    @Inject
+    private Provider<SharedConnectionUserContext> sharedUserContextProvider;
+
+    /**
+     * Service for sharing active connections.
+     */
+    @Inject
+    private ConnectionSharingService sharingService;
+
+    @Override
+    public AuthenticatedUser authenticateUser(AuthenticationProvider authenticationProvider,
+            Credentials credentials) throws GuacamoleException {
+
+        // Check whether user is authenticating with a valid sharing key
+        AuthenticatedUser user = sharingService.retrieveSharedConnectionUser(authenticationProvider, credentials);
+        if (user != null)
+            return user;
+
+        // Otherwise, unauthorized
+        throw new GuacamoleInvalidCredentialsException("Invalid login", CredentialsInfo.USERNAME_PASSWORD);
+
+    }
+
+    @Override
+    public org.apache.guacamole.net.auth.UserContext getUserContext(
+            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+
+        // Produce sharing-specific user context if this is the user of a shared connection
+        if (authenticatedUser instanceof SharedConnectionUser) {
+            SharedConnectionUserContext context = sharedUserContextProvider.get();
+            context.init((SharedConnectionUser) authenticatedUser);
+            return context;
+        }
+
+        // No shared connections otherwise
+        return null;
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProvider.java
@@ -19,7 +19,9 @@
 
 package org.apache.guacamole.auth.mysql;
 
-import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.InjectedAuthenticationProvider;
+import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderService;
 
 /**
  * Provides a MySQL based implementation of the AuthenticationProvider
@@ -28,15 +30,19 @@ import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
  * @author James Muehlner
  * @author Michael Jumper
  */
-public class MySQLAuthenticationProvider extends JDBCAuthenticationProvider {
+public class MySQLAuthenticationProvider extends InjectedAuthenticationProvider {
 
     /**
      * Creates a new MySQLAuthenticationProvider that reads and writes
      * authentication data to a MySQL database defined by properties in
      * guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If a required property is missing, or an error occurs while parsing
+     *     a property.
      */
-    public MySQLAuthenticationProvider() {
-        super(new MySQLInjectorProvider());
+    public MySQLAuthenticationProvider() throws GuacamoleException {
+        super(new MySQLInjectorProvider(), JDBCAuthenticationProviderService.class);
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLInjectorProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLInjectorProvider.java
@@ -19,29 +19,33 @@
 
 package org.apache.guacamole.auth.mysql;
 
-import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderModule;
+import org.apache.guacamole.auth.jdbc.JDBCInjectorProvider;
 
 /**
- * Provides a MySQL based implementation of the AuthenticationProvider
- * functionality.
+ * JDBCInjectorProvider implementation which configures Guice injections for
+ * connecting to a MySQL database based on MySQL-specific options provided via
+ * guacamole.properties.
  *
- * @author James Muehlner
  * @author Michael Jumper
  */
-public class MySQLAuthenticationProvider extends JDBCAuthenticationProvider {
-
-    /**
-     * Creates a new MySQLAuthenticationProvider that reads and writes
-     * authentication data to a MySQL database defined by properties in
-     * guacamole.properties.
-     */
-    public MySQLAuthenticationProvider() {
-        super(new MySQLInjectorProvider());
-    }
+public class MySQLInjectorProvider extends JDBCInjectorProvider {
 
     @Override
-    public String getIdentifier() {
-        return "mysql";
+    protected Injector create() throws GuacamoleException {
+
+        // Get local environment
+        MySQLEnvironment environment = new MySQLEnvironment();
+
+        // Set up Guice injector
+        return Guice.createInjector(
+            new JDBCAuthenticationProviderModule(environment),
+            new MySQLAuthenticationProviderModule(environment)
+        );
+
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLSharedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLSharedAuthenticationProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.mysql;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.InjectedAuthenticationProvider;
+import org.apache.guacamole.auth.jdbc.sharing.SharedAuthenticationProviderService;
+
+/**
+ * Provides a implementation of AuthenticationProvider which interacts with the
+ * MySQL AuthenticationProvider, accepting share keys as credentials and
+ * providing access to the shared connections.
+ *
+ * @author Michael Jumper
+ */
+public class MySQLSharedAuthenticationProvider extends InjectedAuthenticationProvider {
+
+    /**
+     * Creates a new MySQLSharedAuthenticationProvider that provides access to
+     * shared connections exposed by the MySQLAuthenticationProvider.
+     *
+     * @throws GuacamoleException
+     *     If a required property is missing, or an error occurs while parsing
+     *     a property.
+     */
+    public MySQLSharedAuthenticationProvider() throws GuacamoleException {
+        super(new MySQLInjectorProvider(), SharedAuthenticationProviderService.class);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "mysql-shared";
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -6,7 +6,8 @@
     "namespace" : "guac-mysql",
 
     "authProviders" : [
-        "org.apache.guacamole.auth.mysql.MySQLAuthenticationProvider"
+        "org.apache.guacamole.auth.mysql.MySQLAuthenticationProvider",
+        "org.apache.guacamole.auth.mysql.MySQLSharedAuthenticationProvider"
     ],
 
     "translations" : [

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
@@ -19,7 +19,9 @@
 
 package org.apache.guacamole.auth.postgresql;
 
-import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.InjectedAuthenticationProvider;
+import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderService;
 
 /**
  * Provides a PostgreSQL-based implementation of the AuthenticationProvider
@@ -28,15 +30,19 @@ import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
  * @author James Muehlner
  * @author Michael Jumper
  */
-public class PostgreSQLAuthenticationProvider extends JDBCAuthenticationProvider {
+public class PostgreSQLAuthenticationProvider extends InjectedAuthenticationProvider {
 
     /**
      * Creates a new PostgreSQLAuthenticationProvider that reads and writes
      * authentication data to a PostgreSQL database defined by properties in
      * guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If a required property is missing, or an error occurs while parsing
+     *     a property.
      */
-    public PostgreSQLAuthenticationProvider() {
-        super(new PostgreSQLInjectorProvider());
+    public PostgreSQLAuthenticationProvider() throws GuacamoleException {
+        super(new PostgreSQLInjectorProvider(), JDBCAuthenticationProviderService.class);
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLInjectorProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLInjectorProvider.java
@@ -19,29 +19,33 @@
 
 package org.apache.guacamole.auth.postgresql;
 
-import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProvider;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderModule;
+import org.apache.guacamole.auth.jdbc.JDBCInjectorProvider;
 
 /**
- * Provides a PostgreSQL-based implementation of the AuthenticationProvider
- * functionality.
+ * JDBCInjectorProvider implementation which configures Guice injections for
+ * connecting to a PostgreSQL database based on PostgreSQL-specific options
+ * provided via guacamole.properties.
  *
- * @author James Muehlner
  * @author Michael Jumper
  */
-public class PostgreSQLAuthenticationProvider extends JDBCAuthenticationProvider {
-
-    /**
-     * Creates a new PostgreSQLAuthenticationProvider that reads and writes
-     * authentication data to a PostgreSQL database defined by properties in
-     * guacamole.properties.
-     */
-    public PostgreSQLAuthenticationProvider() {
-        super(new PostgreSQLInjectorProvider());
-    }
+public class PostgreSQLInjectorProvider extends JDBCInjectorProvider {
 
     @Override
-    public String getIdentifier() {
-        return "postgresql";
+    protected Injector create() throws GuacamoleException {
+
+        // Get local environment
+        PostgreSQLEnvironment environment = new PostgreSQLEnvironment();
+
+        // Set up Guice injector
+        return Guice.createInjector(
+            new JDBCAuthenticationProviderModule(environment),
+            new PostgreSQLAuthenticationProviderModule(environment)
+        );
+
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLSharedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLSharedAuthenticationProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.postgresql;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.InjectedAuthenticationProvider;
+import org.apache.guacamole.auth.jdbc.sharing.SharedAuthenticationProviderService;
+
+/**
+ * Provides a implementation of AuthenticationProvider which interacts with the
+ * PostgreSQL AuthenticationProvider, accepting share keys as credentials and
+ * providing access to the shared connections.
+ *
+ * @author Michael Jumper
+ */
+public class PostgreSQLSharedAuthenticationProvider extends InjectedAuthenticationProvider {
+
+    /**
+     * Creates a new PostgreSQLSharedAuthenticationProvider that provides access
+     * to shared connections exposed by the PostgreSQLAuthenticationProvider.
+     *
+     * @throws GuacamoleException
+     *     If a required property is missing, or an error occurs while parsing
+     *     a property.
+     */
+    public PostgreSQLSharedAuthenticationProvider() throws GuacamoleException {
+        super(new PostgreSQLInjectorProvider(), SharedAuthenticationProviderService.class);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "postgresql-shared";
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -6,7 +6,8 @@
     "namespace" : "guac-postgresql",
 
     "authProviders" : [
-        "org.apache.guacamole.auth.postgresql.PostgreSQLAuthenticationProvider"
+        "org.apache.guacamole.auth.postgresql.PostgreSQLAuthenticationProvider",
+        "org.apache.guacamole.auth.postgresql.PostgreSQLSharedAuthenticationProvider"
     ],
 
     "translations" : [


### PR DESCRIPTION
The database authentication backend currently implements support for unique "share keys", which can be used as an alternative and temporary method of authentication for accessing shared connections. Prior to this change, it was the duty of the `AuthenticationProvider` to handle both username/password authentication *and* share key authentication.

This change splits the PostgreSQL/MySQL `AuthenticationProvider` implementations into two: one which is specific to username/password auth against the database, and the other which is specific to share key authentication against in-memory shared connections. Both share a common Guice `Injector` and, thus, a common set of core services. Collaborative management of shared connections between the two is achieved through a common service which handles registration and retrieval of shared connections and their corresponding keys.

This change is architectural, as it is a necessary step to cleanly implement support for use of multiple share keys within the same session, even if that session was due to a username/password login. The existing functionality is unaffected.