### PR TITLE
GUACAMOLE-5: Distinguish the authenticating AuthenticationProvider from the data source

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/AuthenticationProviderService.java
@@ -63,6 +63,10 @@ public interface AuthenticationProviderService  {
      * user. A new placeholder account will be created for any user that does
      * not already exist within the database.
      *
+     * @param authenticationProvider
+     *     The AuthenticationProvider on behalf of which the UserContext is
+     *     being produced.
+     *
      * @param authenticatedUser
      *     The credentials to use to produce the UserContext.
      *
@@ -74,7 +78,7 @@ public interface AuthenticationProviderService  {
      *     If an error occurs during authentication, or if the given
      *     credentials are invalid or expired.
      */
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException;
+    public UserContext getUserContext(AuthenticationProvider authenticationProvider,
+            AuthenticatedUser authenticatedUser) throws GuacamoleException;
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
@@ -90,7 +90,7 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
     @Override
     public UserContext getUserContext(AuthenticatedUser authenticatedUser)
             throws GuacamoleException {
-        return authProviderService.getUserContext(authenticatedUser);
+        return authProviderService.getUserContext(this, authenticatedUser);
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderModule.java
@@ -20,7 +20,7 @@
 package org.apache.guacamole.auth.jdbc;
 
 import com.google.inject.Scopes;
-import org.apache.guacamole.auth.jdbc.user.UserContext;
+import org.apache.guacamole.auth.jdbc.user.ModeledUserContext;
 import org.apache.guacamole.auth.jdbc.connectiongroup.RootConnectionGroup;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ConnectionGroupDirectory;
@@ -140,12 +140,12 @@ public class JDBCAuthenticationProviderModule extends MyBatisModule {
         bind(ModeledGuacamoleConfiguration.class);
         bind(ModeledSharingProfile.class);
         bind(ModeledUser.class);
+        bind(ModeledUserContext.class);
         bind(RootConnectionGroup.class);
         bind(SharingProfileDirectory.class);
         bind(SharingProfilePermissionSet.class);
         bind(SystemPermissionSet.class);
         bind(TrackedActiveConnection.class);
-        bind(UserContext.class);
         bind(UserDirectory.class);
         bind(UserPermissionSet.class);
         

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -23,7 +23,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
-import org.apache.guacamole.auth.jdbc.user.UserContext;
+import org.apache.guacamole.auth.jdbc.user.ModeledUserContext;
 import org.apache.guacamole.auth.jdbc.user.UserService;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -50,7 +50,7 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
      * Provider for retrieving UserContext instances.
      */
     @Inject
-    private Provider<UserContext> userContextProvider;
+    private Provider<ModeledUserContext> userContextProvider;
 
     @Override
     public AuthenticatedUser authenticateUser(AuthenticationProvider authenticationProvider,
@@ -67,7 +67,7 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
     }
 
     @Override
-    public UserContext getUserContext(AuthenticationProvider authenticationProvider,
+    public ModeledUserContext getUserContext(AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
         // Retrieve user account for already-authenticated user
@@ -76,7 +76,7 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
             return null;
 
         // Link to user context
-        UserContext context = userContextProvider.get();
+        ModeledUserContext context = userContextProvider.get();
         context.init(user.getCurrentUser());
         return context;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -67,11 +67,11 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
     }
 
     @Override
-    public org.apache.guacamole.net.auth.UserContext getUserContext(
+    public UserContext getUserContext(AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
         // Retrieve user account for already-authenticated user
-        ModeledUser user = userService.retrieveUser(authenticatedUser);
+        ModeledUser user = userService.retrieveUser(authenticationProvider, authenticatedUser);
         if (user == null)
             return null;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
@@ -32,7 +32,7 @@ import org.apache.guacamole.auth.jdbc.permission.AbstractPermissionService;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionService;
 import org.apache.guacamole.auth.jdbc.tunnel.ActiveConnectionRecord;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -60,7 +60,7 @@ public class ActiveConnectionPermissionService
     private Provider<ActiveConnectionPermissionSet> activeConnectionPermissionSetProvider;
 
     @Override
-    public ObjectPermission retrievePermission(AuthenticatedUser user,
+    public ObjectPermission retrievePermission(ModeledAuthenticatedUser user,
             ModeledUser targetUser, ObjectPermission.Type type,
             String identifier) throws GuacamoleException {
 
@@ -78,7 +78,7 @@ public class ActiveConnectionPermissionService
     }
 
     @Override
-    public Set<ObjectPermission> retrievePermissions(AuthenticatedUser user,
+    public Set<ObjectPermission> retrievePermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Retrieve permissions only if allowed
@@ -113,7 +113,7 @@ public class ActiveConnectionPermissionService
     }
 
     @Override
-    public Collection<String> retrieveAccessibleIdentifiers(AuthenticatedUser user,
+    public Collection<String> retrieveAccessibleIdentifiers(ModeledAuthenticatedUser user,
             ModeledUser targetUser, Collection<ObjectPermission.Type> permissionTypes,
             Collection<String> identifiers) throws GuacamoleException {
 
@@ -139,7 +139,7 @@ public class ActiveConnectionPermissionService
     }
 
     @Override
-    public ObjectPermissionSet getPermissionSet(AuthenticatedUser user,
+    public ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
     
         // Create permission set for requested user
@@ -151,7 +151,7 @@ public class ActiveConnectionPermissionService
     }
 
     @Override
-    public void createPermissions(AuthenticatedUser user,
+    public void createPermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser, Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 
@@ -161,7 +161,7 @@ public class ActiveConnectionPermissionService
     }
 
     @Override
-    public void deletePermissions(AuthenticatedUser user,
+    public void deletePermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser, Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.auth.jdbc.base.DirectoryObjectService;
@@ -57,7 +57,7 @@ public class ActiveConnectionService
     private Provider<TrackedActiveConnection> trackedActiveConnectionProvider;
     
     @Override
-    public TrackedActiveConnection retrieveObject(AuthenticatedUser user,
+    public TrackedActiveConnection retrieveObject(ModeledAuthenticatedUser user,
             String identifier) throws GuacamoleException {
 
         // Pull objects having given identifier
@@ -77,7 +77,7 @@ public class ActiveConnectionService
     }
     
     @Override
-    public Collection<TrackedActiveConnection> retrieveObjects(AuthenticatedUser user,
+    public Collection<TrackedActiveConnection> retrieveObjects(ModeledAuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
 
         String username = user.getIdentifier();
@@ -110,7 +110,7 @@ public class ActiveConnectionService
     }
 
     @Override
-    public void deleteObject(AuthenticatedUser user, String identifier)
+    public void deleteObject(ModeledAuthenticatedUser user, String identifier)
         throws GuacamoleException {
 
         // Only administrators may delete active connections
@@ -131,7 +131,7 @@ public class ActiveConnectionService
     }
 
     @Override
-    public Set<String> getIdentifiers(AuthenticatedUser user)
+    public Set<String> getIdentifiers(ModeledAuthenticatedUser user)
         throws GuacamoleException {
 
         // Retrieve all visible connections (permissions enforced by tunnel service)
@@ -147,7 +147,7 @@ public class ActiveConnectionService
     }
 
     @Override
-    public TrackedActiveConnection createObject(AuthenticatedUser user,
+    public TrackedActiveConnection createObject(ModeledAuthenticatedUser user,
             ActiveConnection object) throws GuacamoleException {
 
         // Updating active connections is not implemented
@@ -156,7 +156,7 @@ public class ActiveConnectionService
     }
 
     @Override
-    public void updateObject(AuthenticatedUser user, TrackedActiveConnection object)
+    public void updateObject(ModeledAuthenticatedUser user, TrackedActiveConnection object)
             throws GuacamoleException {
 
         // Updating active connections is not implemented

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
@@ -26,7 +26,7 @@ import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
 import org.apache.guacamole.auth.jdbc.connection.ModeledConnection;
 import org.apache.guacamole.auth.jdbc.sharing.ConnectionSharingService;
 import org.apache.guacamole.auth.jdbc.tunnel.ActiveConnectionRecord;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.credentials.UserCredentials;
@@ -105,7 +105,7 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
      *     as well. This includes the remote host, associated tunnel, and
      *     username.
      */
-    public void init(AuthenticatedUser currentUser,
+    public void init(ModeledAuthenticatedUser currentUser,
             ActiveConnectionRecord activeConnectionRecord,
             boolean includeSensitiveInformation) {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/DirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/DirectoryObjectService.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.base;
 
 import java.util.Collection;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 
 /**
@@ -58,7 +58,7 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      * @throws GuacamoleException
      *     If an error occurs while retrieving the requested object.
      */
-    InternalType retrieveObject(AuthenticatedUser user, String identifier)
+    InternalType retrieveObject(ModeledAuthenticatedUser user, String identifier)
             throws GuacamoleException;
     
     /**
@@ -77,7 +77,7 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      * @throws GuacamoleException
      *     If an error occurs while retrieving the requested objects.
      */
-    Collection<InternalType> retrieveObjects(AuthenticatedUser user,
+    Collection<InternalType> retrieveObjects(ModeledAuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException;
 
     /**
@@ -97,7 +97,7 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      *     If the user lacks permission to create the object, or an error
      *     occurs while creating the object.
      */
-    InternalType createObject(AuthenticatedUser user, ExternalType object)
+    InternalType createObject(ModeledAuthenticatedUser user, ExternalType object)
             throws GuacamoleException;
 
     /**
@@ -114,7 +114,7 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      *     If the user lacks permission to delete the object, or an error
      *     occurs while deleting the object.
      */
-    void deleteObject(AuthenticatedUser user, String identifier)
+    void deleteObject(ModeledAuthenticatedUser user, String identifier)
         throws GuacamoleException;
 
     /**
@@ -131,7 +131,7 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      *     If the user lacks permission to update the object, or an error
      *     occurs while updating the object.
      */
-    void updateObject(AuthenticatedUser user, InternalType object)
+    void updateObject(ModeledAuthenticatedUser user, InternalType object)
             throws GuacamoleException;
 
     /**
@@ -147,6 +147,6 @@ public interface DirectoryObjectService<InternalType, ExternalType> {
      * @throws GuacamoleException
      *     If an error occurs while reading identifiers.
      */
-    Set<String> getIdentifiers(AuthenticatedUser user) throws GuacamoleException;
+    Set<String> getIdentifiers(ModeledAuthenticatedUser user) throws GuacamoleException;
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import javax.xml.stream.events.Characters;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionMapper;
@@ -100,7 +100,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @return
      *     An object which is backed by the given model object.
      */
-    protected abstract InternalType getObjectInstance(AuthenticatedUser currentUser,
+    protected abstract InternalType getObjectInstance(ModeledAuthenticatedUser currentUser,
             ModelType model);
 
     /**
@@ -116,7 +116,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @return
      *     A model object which is based on the given object.
      */
-    protected abstract ModelType getModelInstance(AuthenticatedUser currentUser,
+    protected abstract ModelType getModelInstance(ModeledAuthenticatedUser currentUser,
             ExternalType object);
 
     /**
@@ -133,7 +133,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @throws GuacamoleException
      *     If permission to read the user's permissions is denied.
      */
-    protected abstract boolean hasCreatePermission(AuthenticatedUser user)
+    protected abstract boolean hasCreatePermission(ModeledAuthenticatedUser user)
             throws GuacamoleException;
 
     /**
@@ -156,7 +156,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @throws GuacamoleException
      *     If permission to read the user's permissions is denied.
      */
-    protected boolean hasObjectPermission(AuthenticatedUser user,
+    protected boolean hasObjectPermission(ModeledAuthenticatedUser user,
             String identifier, ObjectPermission.Type type)
             throws GuacamoleException {
 
@@ -184,7 +184,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @throws GuacamoleException
      *     If permission to read the user's permissions is denied.
      */
-    protected abstract ObjectPermissionSet getPermissionSet(AuthenticatedUser user)
+    protected abstract ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user)
             throws GuacamoleException;
 
     /**
@@ -202,7 +202,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *     A collection of objects which are backed by the models in the given
      *     collection.
      */
-    protected Collection<InternalType> getObjectInstances(AuthenticatedUser currentUser,
+    protected Collection<InternalType> getObjectInstances(ModeledAuthenticatedUser currentUser,
             Collection<ModelType> models) {
 
         // Create new collection of objects by manually converting each model
@@ -230,7 +230,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *     If the object is invalid, or an error prevents validating the given
      *     object.
      */
-    protected void beforeCreate(AuthenticatedUser user,
+    protected void beforeCreate(ModeledAuthenticatedUser user,
             ModelType model ) throws GuacamoleException {
 
         // Verify permission to create objects
@@ -255,7 +255,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *     If the object is invalid, or an error prevents validating the given
      *     object.
      */
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             ModelType model) throws GuacamoleException {
 
         // By default, do nothing.
@@ -280,7 +280,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *     If the object is invalid, or an error prevents validating the given
      *     object.
      */
-    protected void beforeDelete(AuthenticatedUser user,
+    protected void beforeDelete(ModeledAuthenticatedUser user,
             String identifier) throws GuacamoleException {
 
         // Verify permission to delete objects
@@ -290,7 +290,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public InternalType retrieveObject(AuthenticatedUser user,
+    public InternalType retrieveObject(ModeledAuthenticatedUser user,
             String identifier) throws GuacamoleException {
 
         // Pull objects having given identifier
@@ -310,7 +310,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public Collection<InternalType> retrieveObjects(AuthenticatedUser user,
+    public Collection<InternalType> retrieveObjects(ModeledAuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
 
         // Ignore invalid identifiers
@@ -350,7 +350,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *     The collection of implicit permissions that should be granted due to
      *     the creation of the given object.
      */
-    protected Collection<ObjectPermissionModel> getImplicitPermissions(AuthenticatedUser user,
+    protected Collection<ObjectPermissionModel> getImplicitPermissions(ModeledAuthenticatedUser user,
             ModelType model) {
         
         // Build list of implicit permissions
@@ -377,7 +377,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public InternalType createObject(AuthenticatedUser user, ExternalType object)
+    public InternalType createObject(ModeledAuthenticatedUser user, ExternalType object)
         throws GuacamoleException {
 
         ModelType model = getModelInstance(user, object);
@@ -397,7 +397,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public void deleteObject(AuthenticatedUser user, String identifier)
+    public void deleteObject(ModeledAuthenticatedUser user, String identifier)
         throws GuacamoleException {
 
         beforeDelete(user, identifier);
@@ -408,7 +408,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public void updateObject(AuthenticatedUser user, InternalType object)
+    public void updateObject(ModeledAuthenticatedUser user, InternalType object)
         throws GuacamoleException {
 
         ModelType model = object.getModel();
@@ -420,7 +420,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     }
 
     @Override
-    public Set<String> getIdentifiers(AuthenticatedUser user)
+    public Set<String> getIdentifiers(ModeledAuthenticatedUser user)
         throws GuacamoleException {
 
         // Bypass permission checks if the user is a system admin

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledGroupedDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledGroupedDirectoryObjectService.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.net.auth.Identifiable;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -76,7 +76,7 @@ public abstract class ModeledGroupedDirectoryObjectService<InternalType extends 
      *     If an error occurs while determining which parent connection groups
      *     are affected.
      */
-    protected Collection<String> getModifiedGroups(AuthenticatedUser user,
+    protected Collection<String> getModifiedGroups(ModeledAuthenticatedUser user,
             String identifier, ModelType model) throws GuacamoleException {
 
         // Get old parent identifier
@@ -130,7 +130,7 @@ public abstract class ModeledGroupedDirectoryObjectService<InternalType extends 
      *     If an error occurs while determining which parent connection groups
      *     are affected.
      */
-    protected boolean canUpdateModifiedGroups(AuthenticatedUser user,
+    protected boolean canUpdateModifiedGroups(ModeledAuthenticatedUser user,
             String identifier, ModelType model) throws GuacamoleException {
 
         // If user is an administrator, no need to check
@@ -156,7 +156,7 @@ public abstract class ModeledGroupedDirectoryObjectService<InternalType extends 
     }
 
     @Override
-    protected void beforeCreate(AuthenticatedUser user,
+    protected void beforeCreate(ModeledAuthenticatedUser user,
             ModelType model) throws GuacamoleException {
 
         super.beforeCreate(user, model);
@@ -168,7 +168,7 @@ public abstract class ModeledGroupedDirectoryObjectService<InternalType extends 
     }
 
     @Override
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             ModelType model) throws GuacamoleException {
 
         super.beforeUpdate(user, model);
@@ -180,7 +180,7 @@ public abstract class ModeledGroupedDirectoryObjectService<InternalType extends 
     }
 
     @Override
-    protected void beforeDelete(AuthenticatedUser user,
+    protected void beforeDelete(ModeledAuthenticatedUser user,
             String identifier) throws GuacamoleException {
 
         super.beforeDelete(user, identifier);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledObject.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledObject.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc.base;
 
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 
 /**
  * Common base class for objects have an underlying model. For the purposes of
@@ -48,7 +48,7 @@ public abstract class ModeledObject<ModelType> extends RestrictedObject {
      * @param model 
      *     The backing model object.
      */
-    public void init(AuthenticatedUser currentUser, ModelType model) {
+    public void init(ModeledAuthenticatedUser currentUser, ModelType model) {
         super.init(currentUser);
         setModel(model);
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RestrictedObject.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RestrictedObject.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc.base;
 
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 
 /**
  * Common base class for objects that are associated with the users that
@@ -33,7 +33,7 @@ public abstract class RestrictedObject {
      * The user this object belongs to. Access is based on his/her permission
      * settings.
      */
-    private AuthenticatedUser currentUser;
+    private ModeledAuthenticatedUser currentUser;
 
     /**
      * Initializes this object, associating it with the current authenticated
@@ -42,7 +42,7 @@ public abstract class RestrictedObject {
      * @param currentUser
      *     The user that created or retrieved this object.
      */
-    public void init(AuthenticatedUser currentUser) {
+    public void init(ModeledAuthenticatedUser currentUser) {
         setCurrentUser(currentUser);
     }
 
@@ -54,7 +54,7 @@ public abstract class RestrictedObject {
      * @return
      *     The user that created or queried this object.
      */
-    public AuthenticatedUser getCurrentUser() {
+    public ModeledAuthenticatedUser getCurrentUser() {
         return currentUser;
     }
 
@@ -66,7 +66,7 @@ public abstract class RestrictedObject {
      * @param currentUser 
      *     The user that created or queried this object.
      */
-    public void setCurrentUser(AuthenticatedUser currentUser) {
+    public void setCurrentUser(ModeledAuthenticatedUser currentUser) {
         this.currentUser = currentUser;
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObjectMapper;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleClientException;
@@ -101,7 +101,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected ModeledConnection getObjectInstance(AuthenticatedUser currentUser,
+    protected ModeledConnection getObjectInstance(ModeledAuthenticatedUser currentUser,
             ConnectionModel model) {
         ModeledConnection connection = connectionProvider.get();
         connection.init(currentUser, model);
@@ -109,7 +109,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected ConnectionModel getModelInstance(AuthenticatedUser currentUser,
+    protected ConnectionModel getModelInstance(ModeledAuthenticatedUser currentUser,
             final Connection object) {
 
         // Create new ModeledConnection backed by blank model
@@ -127,7 +127,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected boolean hasCreatePermission(AuthenticatedUser user)
+    protected boolean hasCreatePermission(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return whether user has explicit connection creation permission
@@ -137,7 +137,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected ObjectPermissionSet getPermissionSet(AuthenticatedUser user)
+    protected ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return permissions related to connections 
@@ -146,7 +146,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected void beforeCreate(AuthenticatedUser user,
+    protected void beforeCreate(ModeledAuthenticatedUser user,
             ConnectionModel model) throws GuacamoleException {
 
         super.beforeCreate(user, model);
@@ -163,7 +163,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             ConnectionModel model) throws GuacamoleException {
 
         super.beforeUpdate(user, model);
@@ -229,7 +229,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
 
     @Override
-    public ModeledConnection createObject(AuthenticatedUser user, Connection object)
+    public ModeledConnection createObject(ModeledAuthenticatedUser user, Connection object)
             throws GuacamoleException {
 
         // Create connection
@@ -246,7 +246,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
     }
     
     @Override
-    public void updateObject(AuthenticatedUser user, ModeledConnection object)
+    public void updateObject(ModeledAuthenticatedUser user, ModeledConnection object)
             throws GuacamoleException {
 
         // Update connection
@@ -282,7 +282,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
      * @throws GuacamoleException
      *     If an error occurs while reading identifiers.
      */
-    public Set<String> getIdentifiersWithin(AuthenticatedUser user,
+    public Set<String> getIdentifiersWithin(ModeledAuthenticatedUser user,
             String identifier)
             throws GuacamoleException {
 
@@ -313,7 +313,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
      *     A new map of all parameter name/value pairs that the given user has
      *     access to.
      */
-    public Map<String, String> retrieveParameters(AuthenticatedUser user,
+    public Map<String, String> retrieveParameters(ModeledAuthenticatedUser user,
             String identifier) {
 
         Map<String, String> parameterMap = new HashMap<String, String>();
@@ -394,7 +394,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
      * @throws GuacamoleException
      *     If permission to read the connection history is denied.
      */
-    public List<ConnectionRecord> retrieveHistory(AuthenticatedUser user,
+    public List<ConnectionRecord> retrieveHistory(ModeledAuthenticatedUser user,
             ModeledConnection connection) throws GuacamoleException {
 
         String identifier = connection.getIdentifier();
@@ -450,7 +450,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
      * @throws GuacamoleException
      *     If permission to read the connection history is denied.
      */
-    public List<ConnectionRecord> retrieveHistory(AuthenticatedUser user,
+    public List<ConnectionRecord> retrieveHistory(ModeledAuthenticatedUser user,
             Collection<ConnectionRecordSearchTerm> requiredContents,
             List<ConnectionRecordSortPredicate> sortPredicates, int limit)
             throws GuacamoleException {
@@ -492,7 +492,7 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
      * @throws GuacamoleException
      *     If permission to connect to this connection is denied.
      */
-    public GuacamoleTunnel connect(AuthenticatedUser user,
+    public GuacamoleTunnel connect(ModeledAuthenticatedUser user,
             ModeledConnection connection, GuacamoleClientInformation info)
             throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledGuacamoleConfiguration.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledGuacamoleConfiguration.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.connection;
 
 import com.google.inject.Inject;
 import java.util.Map;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
 
 /**
@@ -36,7 +36,7 @@ public class ModeledGuacamoleConfiguration extends GuacamoleConfiguration {
      * The user this configuration belongs to. Access is based on his/her
      * permission settings.
      */
-    private AuthenticatedUser currentUser;
+    private ModeledAuthenticatedUser currentUser;
 
     /**
      * The internal model object containing the values which represent the
@@ -72,7 +72,7 @@ public class ModeledGuacamoleConfiguration extends GuacamoleConfiguration {
      * @param connectionModel 
      *     The model object backing this configuration.
      */
-    public void init(AuthenticatedUser currentUser, ConnectionModel connectionModel) {
+    public void init(ModeledAuthenticatedUser currentUser, ConnectionModel connectionModel) {
         this.currentUser = currentUser;
         this.connectionModel = connectionModel;
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.auth.jdbc.connectiongroup;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObjectMapper;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleClientException;
@@ -84,7 +84,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected ModeledConnectionGroup getObjectInstance(AuthenticatedUser currentUser,
+    protected ModeledConnectionGroup getObjectInstance(ModeledAuthenticatedUser currentUser,
             ConnectionGroupModel model) {
         ModeledConnectionGroup connectionGroup = connectionGroupProvider.get();
         connectionGroup.init(currentUser, model);
@@ -92,7 +92,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected ConnectionGroupModel getModelInstance(AuthenticatedUser currentUser,
+    protected ConnectionGroupModel getModelInstance(ModeledAuthenticatedUser currentUser,
             final ConnectionGroup object) {
 
         // Create new ModeledConnectionGroup backed by blank model
@@ -110,7 +110,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected boolean hasCreatePermission(AuthenticatedUser user)
+    protected boolean hasCreatePermission(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return whether user has explicit connection group creation permission
@@ -120,7 +120,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected ObjectPermissionSet getPermissionSet(AuthenticatedUser user)
+    protected ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return permissions related to connection groups 
@@ -129,7 +129,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected void beforeCreate(AuthenticatedUser user,
+    protected void beforeCreate(ModeledAuthenticatedUser user,
             ConnectionGroupModel model) throws GuacamoleException {
 
         super.beforeCreate(user, model);
@@ -146,7 +146,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
     }
 
     @Override
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             ConnectionGroupModel model) throws GuacamoleException {
 
         super.beforeUpdate(user, model);
@@ -204,7 +204,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
      * @throws GuacamoleException
      *     If an error occurs while reading identifiers.
      */
-    public Set<String> getIdentifiersWithin(AuthenticatedUser user,
+    public Set<String> getIdentifiersWithin(ModeledAuthenticatedUser user,
             String identifier)
             throws GuacamoleException {
 
@@ -239,7 +239,7 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
      * @throws GuacamoleException
      *     If permission to connect to this connection is denied.
      */
-    public GuacamoleTunnel connect(AuthenticatedUser user,
+    public GuacamoleTunnel connect(ModeledAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup, GuacamoleClientInformation info)
             throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc.permission;
 
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
@@ -61,7 +61,7 @@ public abstract class AbstractPermissionService<PermissionSetType extends Permis
      *     If an error occurs while checking permission status, or if
      *     permission is denied to read the current user's permissions.
      */
-    protected boolean canReadPermissions(AuthenticatedUser user,
+    protected boolean canReadPermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // A user can always read their own permissions

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ConnectionGroupPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ConnectionGroupPermissionService.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 
@@ -52,7 +52,7 @@ public class ConnectionGroupPermissionService extends ModeledObjectPermissionSer
     }
 
     @Override
-    public ObjectPermissionSet getPermissionSet(AuthenticatedUser user,
+    public ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Create permission set for requested user

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ConnectionPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ConnectionPermissionService.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 
@@ -52,7 +52,7 @@ public class ConnectionPermissionService extends ModeledObjectPermissionService 
     }
 
     @Override
-    public ObjectPermissionSet getPermissionSet(AuthenticatedUser user,
+    public ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Create permission set for requested user

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -89,7 +89,7 @@ public abstract class ModeledObjectPermissionService
      *     If an error occurs while checking permission status, or if
      *     permission is denied to read the current user's permissions.
      */
-    protected boolean canAlterPermissions(AuthenticatedUser user, ModeledUser targetUser,
+    protected boolean canAlterPermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 
@@ -123,7 +123,7 @@ public abstract class ModeledObjectPermissionService
     }
     
     @Override
-    public void createPermissions(AuthenticatedUser user, ModeledUser targetUser,
+    public void createPermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 
@@ -140,7 +140,7 @@ public abstract class ModeledObjectPermissionService
     }
 
     @Override
-    public void deletePermissions(AuthenticatedUser user, ModeledUser targetUser,
+    public void deletePermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 
@@ -157,7 +157,7 @@ public abstract class ModeledObjectPermissionService
     }
 
     @Override
-    public ObjectPermission retrievePermission(AuthenticatedUser user,
+    public ObjectPermission retrievePermission(ModeledAuthenticatedUser user,
             ModeledUser targetUser, ObjectPermission.Type type,
             String identifier) throws GuacamoleException {
 
@@ -179,7 +179,7 @@ public abstract class ModeledObjectPermissionService
     }
 
     @Override
-    public Collection<String> retrieveAccessibleIdentifiers(AuthenticatedUser user,
+    public Collection<String> retrieveAccessibleIdentifiers(ModeledAuthenticatedUser user,
             ModeledUser targetUser, Collection<ObjectPermission.Type> permissions,
             Collection<String> identifiers) throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledPermissionService.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -140,7 +140,7 @@ public abstract class ModeledPermissionService<PermissionSetType extends Permiss
     }
 
     @Override
-    public Set<PermissionType> retrievePermissions(AuthenticatedUser user,
+    public Set<PermissionType> retrievePermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Retrieve permissions only if allowed

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ObjectPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ObjectPermissionService.java
@@ -20,7 +20,7 @@
 package org.apache.guacamole.auth.jdbc.permission;
 
 import java.util.Collection;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
@@ -59,7 +59,7 @@ public interface ObjectPermissionService
      * @throws GuacamoleException
      *     If an error occurs while retrieving the requested permission.
      */
-    ObjectPermission retrievePermission(AuthenticatedUser user,
+    ObjectPermission retrievePermission(ModeledAuthenticatedUser user,
             ModeledUser targetUser, ObjectPermission.Type type,
             String identifier) throws GuacamoleException;
 
@@ -89,7 +89,7 @@ public interface ObjectPermissionService
      * @throws GuacamoleException
      *     If an error occurs while retrieving permissions.
      */
-    Collection<String> retrieveAccessibleIdentifiers(AuthenticatedUser user,
+    Collection<String> retrieveAccessibleIdentifiers(ModeledAuthenticatedUser user,
             ModeledUser targetUser, Collection<ObjectPermission.Type> permissions,
             Collection<String> identifiers) throws GuacamoleException;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ObjectPermissionSet.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ObjectPermissionSet.java
@@ -23,7 +23,7 @@ import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
@@ -63,7 +63,7 @@ public abstract class ObjectPermissionSet extends RestrictedObject
      * @param user
      *     The user to whom the permissions in this set are granted.
      */
-    public void init(AuthenticatedUser currentUser, ModeledUser user) {
+    public void init(ModeledAuthenticatedUser currentUser, ModeledUser user) {
         super.init(currentUser);
         this.user = user;
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/PermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/PermissionService.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -69,7 +69,7 @@ public interface PermissionService<PermissionSetType extends PermissionSet<Permi
      *     user, or if permission to retrieve the permissions of the given
      *     user is denied.
      */
-    PermissionSetType getPermissionSet(AuthenticatedUser user,
+    PermissionSetType getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException;
 
     /**
@@ -87,7 +87,7 @@ public interface PermissionService<PermissionSetType extends PermissionSet<Permi
      * @throws GuacamoleException
      *     If an error occurs while retrieving the requested permissions.
      */
-    Set<PermissionType> retrievePermissions(AuthenticatedUser user,
+    Set<PermissionType> retrievePermissions(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException;
 
     /**
@@ -107,7 +107,7 @@ public interface PermissionService<PermissionSetType extends PermissionSet<Permi
      *     If the user lacks permission to create the permissions, or an error
      *     occurs while creating the permissions.
      */
-    void createPermissions(AuthenticatedUser user, ModeledUser targetUser,
+    void createPermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<PermissionType> permissions) throws GuacamoleException;
 
     /**
@@ -127,7 +127,7 @@ public interface PermissionService<PermissionSetType extends PermissionSet<Permi
      *     If the user lacks permission to delete the permissions, or an error
      *     occurs while deleting the permissions.
      */
-    void deletePermissions(AuthenticatedUser user, ModeledUser targetUser,
+    void deletePermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<PermissionType> permissions) throws GuacamoleException;
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SharingProfilePermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SharingProfilePermissionService.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 
@@ -52,7 +52,7 @@ public class SharingProfilePermissionService extends ModeledObjectPermissionServ
     }
 
     @Override
-    public ObjectPermissionSet getPermissionSet(AuthenticatedUser user,
+    public ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Create permission set for requested user

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.Collection;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -77,7 +77,7 @@ public class SystemPermissionService
     }
 
     @Override
-    public SystemPermissionSet getPermissionSet(AuthenticatedUser user,
+    public SystemPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Create permission set for requested user
@@ -89,7 +89,7 @@ public class SystemPermissionService
     }
     
     @Override
-    public void createPermissions(AuthenticatedUser user, ModeledUser targetUser,
+    public void createPermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
         // Only an admin can create system permissions
@@ -105,7 +105,7 @@ public class SystemPermissionService
     }
 
     @Override
-    public void deletePermissions(AuthenticatedUser user, ModeledUser targetUser,
+    public void deletePermissions(ModeledAuthenticatedUser user, ModeledUser targetUser,
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
         // Only an admin can delete system permissions
@@ -145,7 +145,7 @@ public class SystemPermissionService
      * @throws GuacamoleException
      *     If an error occurs while retrieving the requested permission.
      */
-    public SystemPermission retrievePermission(AuthenticatedUser user,
+    public SystemPermission retrievePermission(ModeledAuthenticatedUser user,
             ModeledUser targetUser, SystemPermission.Type type) throws GuacamoleException {
 
         // Retrieve permissions only if allowed

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionSet.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionSet.java
@@ -23,7 +23,7 @@ import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
 import org.apache.guacamole.net.auth.permission.SystemPermission;
@@ -69,7 +69,7 @@ public class SystemPermissionSet extends RestrictedObject
      * @param user
      *     The user to whom the permissions in this set are granted.
      */
-    public void init(AuthenticatedUser currentUser, ModeledUser user) {
+    public void init(ModeledAuthenticatedUser currentUser, ModeledUser user) {
         super.init(currentUser);
         this.user = user;
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/UserPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/UserPermissionService.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.permission;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 
@@ -52,7 +52,7 @@ public class UserPermissionService extends ModeledObjectPermissionService {
     }
 
     @Override
-    public ObjectPermissionSet getPermissionSet(AuthenticatedUser user,
+    public ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user,
             ModeledUser targetUser) throws GuacamoleException {
 
         // Create permission set for requested user

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/ConnectionSharingService.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.auth.jdbc.sharing;
 import com.google.inject.Inject;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
@@ -97,7 +97,7 @@ public class ConnectionSharingService {
      * @throws GuacamoleException
      *     If permission to share the given connection is denied.
      */
-    public UserCredentials generateTemporaryCredentials(AuthenticatedUser user,
+    public UserCredentials generateTemporaryCredentials(ModeledAuthenticatedUser user,
             ActiveConnectionRecord activeConnection,
             String sharingProfileIdentifier) throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SharedAuthenticationProviderService.java
@@ -67,6 +67,7 @@ public class SharedAuthenticationProviderService implements AuthenticationProvid
 
     @Override
     public org.apache.guacamole.net.auth.UserContext getUserContext(
+            AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
         // Produce sharing-specific user context if this is the user of a shared connection

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileService.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObjectMapper;
 import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
@@ -84,7 +84,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected ModeledSharingProfile getObjectInstance(AuthenticatedUser currentUser,
+    protected ModeledSharingProfile getObjectInstance(ModeledAuthenticatedUser currentUser,
             SharingProfileModel model) {
         ModeledSharingProfile sharingProfile = sharingProfileProvider.get();
         sharingProfile.init(currentUser, model);
@@ -92,7 +92,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected SharingProfileModel getModelInstance(AuthenticatedUser currentUser,
+    protected SharingProfileModel getModelInstance(ModeledAuthenticatedUser currentUser,
             final SharingProfile object) {
 
         // Create new ModeledSharingProfile backed by blank model
@@ -111,7 +111,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected boolean hasCreatePermission(AuthenticatedUser user)
+    protected boolean hasCreatePermission(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return whether user has explicit sharing profile creation permission
@@ -121,7 +121,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected ObjectPermissionSet getPermissionSet(AuthenticatedUser user)
+    protected ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return permissions related to sharing profiles
@@ -130,7 +130,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected void beforeCreate(AuthenticatedUser user,
+    protected void beforeCreate(ModeledAuthenticatedUser user,
             SharingProfileModel model) throws GuacamoleException {
 
         super.beforeCreate(user, model);
@@ -147,7 +147,7 @@ public class SharingProfileService
     }
 
     @Override
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             SharingProfileModel model) throws GuacamoleException {
 
         super.beforeUpdate(user, model);
@@ -213,7 +213,7 @@ public class SharingProfileService
     }
 
     @Override
-    public ModeledSharingProfile createObject(AuthenticatedUser user, SharingProfile object)
+    public ModeledSharingProfile createObject(ModeledAuthenticatedUser user, SharingProfile object)
             throws GuacamoleException {
 
         // Create sharing profile
@@ -230,7 +230,7 @@ public class SharingProfileService
     }
     
     @Override
-    public void updateObject(AuthenticatedUser user, ModeledSharingProfile object)
+    public void updateObject(ModeledAuthenticatedUser user, ModeledSharingProfile object)
             throws GuacamoleException {
 
         // Update sharing profile
@@ -266,7 +266,7 @@ public class SharingProfileService
      * @throws GuacamoleException
      *     If an error occurs while reading identifiers.
      */
-    public Set<String> getIdentifiersWithin(AuthenticatedUser user,
+    public Set<String> getIdentifiersWithin(ModeledAuthenticatedUser user,
             String identifier)
             throws GuacamoleException {
 
@@ -298,7 +298,7 @@ public class SharingProfileService
      *     A new map of all parameter name/value pairs that the given user has
      *     access to.
      */
-    public Map<String, String> retrieveParameters(AuthenticatedUser user,
+    public Map<String, String> retrieveParameters(ModeledAuthenticatedUser user,
             String identifier) {
 
         Map<String, String> parameterMap = new HashMap<String, String>();

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.connection.ModeledConnection;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
 import org.apache.guacamole.auth.jdbc.connection.ConnectionRecordMapper;
@@ -522,7 +522,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
      *     provided identifiers are preferred, the original collection of
      *     identifiers.
      */
-    private Collection<String> getPreferredConnections(AuthenticatedUser user,
+    private Collection<String> getPreferredConnections(ModeledAuthenticatedUser user,
             Collection<String> identifiers) {
 
         // Search provided identifiers for any preferred connections
@@ -556,7 +556,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
      *     A list containing all balanced connections within the given group,
      *     or an empty list if there are no such connections.
      */
-    private List<ModeledConnection> getBalancedConnections(AuthenticatedUser user,
+    private List<ModeledConnection> getBalancedConnections(ModeledAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup) {
 
         // If not a balancing group, there are no balanced connections
@@ -588,7 +588,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
     }
 
     @Override
-    public Collection<ActiveConnectionRecord> getActiveConnections(AuthenticatedUser user)
+    public Collection<ActiveConnectionRecord> getActiveConnections(ModeledAuthenticatedUser user)
         throws GuacamoleException {
 
         // Simply return empty list if there are no active tunnels
@@ -626,7 +626,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
 
     @Override
     @Transactional
-    public GuacamoleTunnel getGuacamoleTunnel(final AuthenticatedUser user,
+    public GuacamoleTunnel getGuacamoleTunnel(final ModeledAuthenticatedUser user,
             final ModeledConnection connection, GuacamoleClientInformation info)
             throws GuacamoleException {
 
@@ -647,7 +647,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
 
     @Override
     @Transactional
-    public GuacamoleTunnel getGuacamoleTunnel(AuthenticatedUser user,
+    public GuacamoleTunnel getGuacamoleTunnel(ModeledAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup,
             GuacamoleClientInformation info) throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
@@ -20,7 +20,7 @@
 package org.apache.guacamole.auth.jdbc.tunnel;
 
 import java.util.Collection;
-import org.apache.guacamole.auth.jdbc.user.AuthenticatedUser;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.connection.ModeledConnection;
 import org.apache.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
 import org.apache.guacamole.GuacamoleException;
@@ -55,7 +55,7 @@ public interface GuacamoleTunnelService {
      *     If an error occurs while retrieving all active connections, or if
      *     permission is denied.
      */
-    public Collection<ActiveConnectionRecord> getActiveConnections(AuthenticatedUser user)
+    public Collection<ActiveConnectionRecord> getActiveConnections(ModeledAuthenticatedUser user)
             throws GuacamoleException;
 
     /**
@@ -83,7 +83,7 @@ public interface GuacamoleTunnelService {
      *     If the connection cannot be established due to concurrent usage
      *     rules.
      */
-    GuacamoleTunnel getGuacamoleTunnel(AuthenticatedUser user,
+    GuacamoleTunnel getGuacamoleTunnel(ModeledAuthenticatedUser user,
             ModeledConnection connection, GuacamoleClientInformation info)
             throws GuacamoleException;
 
@@ -127,7 +127,7 @@ public interface GuacamoleTunnelService {
      *     If the connection cannot be established due to concurrent usage
      *     rules, or if the connection group is not balancing.
      */
-    GuacamoleTunnel getGuacamoleTunnel(AuthenticatedUser user,
+    GuacamoleTunnel getGuacamoleTunnel(ModeledAuthenticatedUser user,
             ModeledConnectionGroup connectionGroup,
             GuacamoleClientInformation info)
             throws GuacamoleException;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/AuthenticatedUser.java
@@ -33,9 +33,16 @@ import org.apache.guacamole.net.auth.Credentials;
 public class AuthenticatedUser extends RemoteAuthenticatedUser {
 
     /**
-     * The user that authenticated.
+     * The ModeledUser object which is backed by the data associated with this
+     * user in the database.
      */
     private final ModeledUser user;
+
+    /**
+     * The AuthenticationProvider that is associated with this user's
+     * corresponding ModeledUser.
+     */
+    private final AuthenticationProvider modelAuthenticationProvider;
 
     /**
      * The connections which have been committed for use by this user in the
@@ -49,14 +56,41 @@ public class AuthenticatedUser extends RemoteAuthenticatedUser {
             Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
     /**
+     * Creates a copy of the given AuthenticatedUser which is associated with
+     * the data stored in the provided ModeledUser. The AuthenticatedUser need
+     * not have come from the same AuthenticationProvider which produced the
+     * given ModeledUser.
+     *
+     * @param authenticatedUser
+     *     An existing AuthenticatedUser representing the user that
+     *     authenticated.
+     *
+     * @param modelAuthenticationProvider
+     *     The AuthenticationProvider that is associated with the given user's
+     *     corresponding ModeledUser.
+     *
+     * @param user
+     *     A ModeledUser object which is backed by the data associated with
+     *     this user in the database.
+     */
+    public AuthenticatedUser(org.apache.guacamole.net.auth.AuthenticatedUser authenticatedUser,
+            AuthenticationProvider modelAuthenticationProvider, ModeledUser user) {
+        super(authenticatedUser.getAuthenticationProvider(), authenticatedUser.getCredentials());
+        this.modelAuthenticationProvider = modelAuthenticationProvider;
+        this.user = user;
+    }
+
+    /**
      * Creates a new AuthenticatedUser associating the given user with their
      * corresponding credentials.
      *
      * @param authenticationProvider
-     *     The AuthenticationProvider that has authenticated the given user.
+     *     The AuthenticationProvider that has authenticated the given user
+     *     and which produced the given ModeledUser.
      *
      * @param user
-     *     The user this object should represent.
+     *     A ModeledUser object which is backed by the data associated with
+     *     this user in the database.
      *
      * @param credentials 
      *     The credentials given by the user when they authenticated.
@@ -64,17 +98,34 @@ public class AuthenticatedUser extends RemoteAuthenticatedUser {
     public AuthenticatedUser(AuthenticationProvider authenticationProvider,
             ModeledUser user, Credentials credentials) {
         super(authenticationProvider, credentials);
+        this.modelAuthenticationProvider = authenticationProvider;
         this.user = user;
     }
 
     /**
-     * Returns the user that authenticated.
+     * Returns a ModeledUser object which is backed by the data associated with
+     * this user within the database.
      *
      * @return 
-     *     The user that authenticated.
+     *     A ModeledUser object which is backed by the data associated with
+     *     this user in the database.
      */
     public ModeledUser getUser() {
         return user;
+    }
+
+    /**
+     * Returns the AuthenticationProvider which produced the ModeledUser
+     * retrievable via getUser(). This is not necessarily the same as the
+     * AuthenticationProvider which authenticated that user, which can be
+     * retrieved with getAuthenticationProvider().
+     *
+     * @return
+     *     The AuthenticationProvider which produced the ModeledUser
+     *     retrievable via getUser().
+     */
+    public AuthenticationProvider getModelAuthenticationProvider() {
+        return modelAuthenticationProvider;
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -22,15 +22,18 @@ package org.apache.guacamole.auth.jdbc.user;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 
 /**
- * Associates a user with the credentials they used to authenticate.
+ * Associates a user with the credentials they used to authenticate, their
+ * corresponding ModeledUser, and the AuthenticationProvider which produced
+ * that ModeledUser.
  *
  * @author Michael Jumper 
  */
-public class AuthenticatedUser extends RemoteAuthenticatedUser {
+public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
 
     /**
      * The ModeledUser object which is backed by the data associated with this
@@ -73,7 +76,7 @@ public class AuthenticatedUser extends RemoteAuthenticatedUser {
      *     A ModeledUser object which is backed by the data associated with
      *     this user in the database.
      */
-    public AuthenticatedUser(org.apache.guacamole.net.auth.AuthenticatedUser authenticatedUser,
+    public ModeledAuthenticatedUser(AuthenticatedUser authenticatedUser,
             AuthenticationProvider modelAuthenticationProvider, ModeledUser user) {
         super(authenticatedUser.getAuthenticationProvider(), authenticatedUser.getCredentials());
         this.modelAuthenticationProvider = modelAuthenticationProvider;
@@ -95,7 +98,7 @@ public class AuthenticatedUser extends RemoteAuthenticatedUser {
      * @param credentials 
      *     The credentials given by the user when they authenticated.
      */
-    public AuthenticatedUser(AuthenticationProvider authenticationProvider,
+    public ModeledAuthenticatedUser(AuthenticationProvider authenticationProvider,
             ModeledUser user, Credentials credentials) {
         super(authenticationProvider, credentials);
         this.modelAuthenticationProvider = authenticationProvider;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -50,7 +50,7 @@ import org.apache.guacamole.net.auth.User;
  * @author James Muehlner
  * @author Michael Jumper
  */
-public class UserContext extends RestrictedObject
+public class ModeledUserContext extends RestrictedObject
     implements org.apache.guacamole.net.auth.UserContext {
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
@@ -101,7 +101,7 @@ public class UserContext extends RestrictedObject
     private Provider<ConnectionRecordSet> connectionRecordSetProvider;
     
     @Override
-    public void init(AuthenticatedUser currentUser) {
+    public void init(ModeledAuthenticatedUser currentUser) {
 
         super.init(currentUser);
         

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserContext.java
@@ -121,7 +121,7 @@ public class UserContext extends RestrictedObject
 
     @Override
     public AuthenticationProvider getAuthenticationProvider() {
-        return getCurrentUser().getAuthenticationProvider();
+        return getCurrentUser().getModelAuthenticationProvider();
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -37,6 +37,7 @@ import org.apache.guacamole.auth.jdbc.permission.UserPermissionMapper;
 import org.apache.guacamole.auth.jdbc.security.PasswordEncryptionService;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.PasswordField;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
@@ -140,7 +141,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected ModeledUser getObjectInstance(AuthenticatedUser currentUser,
+    protected ModeledUser getObjectInstance(ModeledAuthenticatedUser currentUser,
             UserModel model) {
         ModeledUser user = userProvider.get();
         user.init(currentUser, model);
@@ -148,7 +149,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected UserModel getModelInstance(AuthenticatedUser currentUser,
+    protected UserModel getModelInstance(ModeledAuthenticatedUser currentUser,
             final User object) {
 
         // Create new ModeledUser backed by blank model
@@ -165,7 +166,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected boolean hasCreatePermission(AuthenticatedUser user)
+    protected boolean hasCreatePermission(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return whether user has explicit user creation permission
@@ -175,7 +176,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected ObjectPermissionSet getPermissionSet(AuthenticatedUser user)
+    protected ObjectPermissionSet getPermissionSet(ModeledAuthenticatedUser user)
             throws GuacamoleException {
 
         // Return permissions related to users
@@ -184,7 +185,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected void beforeCreate(AuthenticatedUser user, UserModel model)
+    protected void beforeCreate(ModeledAuthenticatedUser user, UserModel model)
             throws GuacamoleException {
 
         super.beforeCreate(user, model);
@@ -201,7 +202,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
 
     @Override
-    protected void beforeUpdate(AuthenticatedUser user,
+    protected void beforeUpdate(ModeledAuthenticatedUser user,
             UserModel model) throws GuacamoleException {
 
         super.beforeUpdate(user, model);
@@ -224,7 +225,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
     @Override
     protected Collection<ObjectPermissionModel>
-        getImplicitPermissions(AuthenticatedUser user, UserModel model) {
+        getImplicitPermissions(ModeledAuthenticatedUser user, UserModel model) {
             
         // Get original set of implicit permissions
         Collection<ObjectPermissionModel> implicitPermissions = super.getImplicitPermissions(user, model);
@@ -247,7 +248,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     }
         
     @Override
-    protected void beforeDelete(AuthenticatedUser user, String identifier) throws GuacamoleException {
+    protected void beforeDelete(ModeledAuthenticatedUser user, String identifier) throws GuacamoleException {
 
         super.beforeDelete(user, identifier);
 
@@ -277,7 +278,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      * @throws GuacamoleException
      *     If the provided credentials to not conform to expectations.
      */
-    public AuthenticatedUser retrieveAuthenticatedUser(AuthenticationProvider authenticationProvider,
+    public ModeledAuthenticatedUser retrieveAuthenticatedUser(AuthenticationProvider authenticationProvider,
             Credentials credentials) throws GuacamoleException {
 
         // Get username and password
@@ -300,7 +301,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         // Create corresponding user object, set up cyclic reference
         ModeledUser user = getObjectInstance(null, userModel);
-        user.setCurrentUser(new AuthenticatedUser(authenticationProvider, user, credentials));
+        user.setCurrentUser(new ModeledAuthenticatedUser(authenticationProvider, user, credentials));
 
         // Verify user account is still valid as of today
         if (!user.isAccountValid())
@@ -365,11 +366,11 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      *     null if no such user exists.
      */
     public ModeledUser retrieveUser(AuthenticationProvider authenticationProvider,
-            org.apache.guacamole.net.auth.AuthenticatedUser authenticatedUser) {
+            AuthenticatedUser authenticatedUser) {
 
         // If we already queried this user, return that rather than querying again
-        if (authenticatedUser instanceof AuthenticatedUser)
-            return ((AuthenticatedUser) authenticatedUser).getUser();
+        if (authenticatedUser instanceof ModeledAuthenticatedUser)
+            return ((ModeledAuthenticatedUser) authenticatedUser).getUser();
 
         // Get username
         String username = authenticatedUser.getIdentifier();
@@ -381,7 +382,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         // Create corresponding user object, set up cyclic reference
         ModeledUser user = getObjectInstance(null, userModel);
-        user.setCurrentUser(new AuthenticatedUser(authenticatedUser,
+        user.setCurrentUser(new ModeledAuthenticatedUser(authenticatedUser,
                 authenticationProvider, user));
 
         // Return already-authenticated user

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -353,6 +353,10 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      * Retrieves the user corresponding to the given AuthenticatedUser from the
      * database.
      *
+     * @param authenticationProvider
+     *     The AuthenticationProvider on behalf of which the user is being
+     *     retrieved.
+     *
      * @param authenticatedUser
      *     The AuthenticatedUser to retrieve the corresponding ModeledUser of.
      *
@@ -360,7 +364,8 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      *     The ModeledUser which corresponds to the given AuthenticatedUser, or
      *     null if no such user exists.
      */
-    public ModeledUser retrieveUser(org.apache.guacamole.net.auth.AuthenticatedUser authenticatedUser) {
+    public ModeledUser retrieveUser(AuthenticationProvider authenticationProvider,
+            org.apache.guacamole.net.auth.AuthenticatedUser authenticatedUser) {
 
         // If we already queried this user, return that rather than querying again
         if (authenticatedUser instanceof AuthenticatedUser)
@@ -376,7 +381,8 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         // Create corresponding user object, set up cyclic reference
         ModeledUser user = getObjectInstance(null, userModel);
-        user.setCurrentUser(new AuthenticatedUser(authenticatedUser.getAuthenticationProvider(), user, authenticatedUser.getCredentials()));
+        user.setCurrentUser(new AuthenticatedUser(authenticatedUser,
+                authenticationProvider, user));
 
         // Return already-authenticated user
         return user;


### PR DESCRIPTION
The changes from #36 were partly wrong, as `getAuthenticationProvider()` of `AuthenticatedUser` will not always return the same `AuthenticationProvider` that owns the data within the `UserContext`. As written, the value returned by `getAuthenticationProvider()` of `UserContext` will be wrong for any case where the `AuthenticatedUser` was authenticated by an `AuthenticationProvider` that isn't the source of that same `UserContext`.

This change establishes a clear distinction, within the context of the database extension, between the `AuthenticationProvider` which authenticated the user and the database-specific `AuthenticationProvider` implementation which serves as the data source.

Much of this is a rename of the database-specific `AuthenticatedUser` implementation to `ModeledAuthenticatedUser`, and `UserContext` to `ModeledUserContext`, both for the sake of future clarity, but there are also substantive changes which fix the actual bug introduced by #36, particularly in the use of the new `getModelAuthenticationProvider()` instead of `getAuthenticationProvider()`.