### PR TITLE
GUACAMOLE-5: Provide most recent Credentials to updateUserContext()

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
@@ -95,7 +95,8 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
 
     @Override
     public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+            AuthenticatedUser authenticatedUser, Credentials credentials)
+            throws GuacamoleException {
 
         // No need to update the context
         return context;

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
@@ -20,8 +20,6 @@
 package org.apache.guacamole.auth.ldap;
 
 
-import org.apache.guacamole.auth.ldap.AuthenticationProviderService;
-import org.apache.guacamole.auth.ldap.LDAPAuthenticationProviderModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
@@ -97,7 +95,8 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
 
     @Override
     public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+            AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
         return context;
     }
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
@@ -130,6 +130,11 @@ public interface AuthenticationProvider {
      *     this AuthenticationProvider or any other installed
      *     AuthenticationProvider.
      *
+     * @param credentials
+     *     The credentials which were most recently submitted. These are not
+     *     guaranteed to be the same as the credentials associated with the
+     *     AuthenticatedUser when they originally authenticated.
+     *
      * @return
      *     An updated UserContext describing the permissions, connection,
      *     connection groups, etc. accessible or associated with the given
@@ -140,6 +145,7 @@ public interface AuthenticationProvider {
      *     If an error occurs while updating the UserContext.
      */
     UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException;
+            AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException;
     
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -251,7 +251,8 @@ public abstract class SimpleAuthenticationProvider
 
     @Override
     public UserContext updateUserContext(UserContext context,
-        AuthenticatedUser authorizedUser) throws GuacamoleException {
+        AuthenticatedUser authorizedUser, Credentials credentials)
+            throws GuacamoleException {
 
         // Simply return the given context, updating nothing
         return context;

--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -183,7 +183,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
     @Override
     public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser)
+            AuthenticatedUser authenticatedUser, Credentials credentials)
             throws GuacamoleException {
 
         // Ignore auth attempts if no auth provider could be loaded
@@ -193,7 +193,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
         }
 
         // Delegate to underlying auth provider
-        return authProvider.updateUserContext(context, authenticatedUser);
+        return authProvider.updateUserContext(context, authenticatedUser, credentials);
         
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -288,6 +288,10 @@ public class AuthenticationService {
      *     The AuthenticatedUser that has successfully authenticated or re-
      *     authenticated.
      *
+     * @param credentials
+     *     The Credentials provided by the user in the most recent
+     *     authentication attempt.
+     *
      * @return
      *     A List of all UserContexts associated with the given
      *     AuthenticatedUser.
@@ -296,7 +300,8 @@ public class AuthenticationService {
      *     If an error occurs while creating or updating any UserContext.
      */
     private List<UserContext> getUserContexts(GuacamoleSession existingSession,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+            AuthenticatedUser authenticatedUser, Credentials credentials)
+            throws GuacamoleException {
 
         List<UserContext> userContexts = new ArrayList<UserContext>(authProviders.size());
 
@@ -309,7 +314,7 @@ public class AuthenticationService {
 
                 // Update existing UserContext
                 AuthenticationProvider authProvider = oldUserContext.getAuthenticationProvider();
-                UserContext userContext = authProvider.updateUserContext(oldUserContext, authenticatedUser);
+                UserContext userContext = authProvider.updateUserContext(oldUserContext, authenticatedUser, credentials);
 
                 // Add to available data, if successful
                 if (userContext != null)
@@ -379,7 +384,7 @@ public class AuthenticationService {
 
         // Get up-to-date AuthenticatedUser and associated UserContexts
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(existingSession, credentials);
-        List<UserContext> userContexts = getUserContexts(existingSession, authenticatedUser);
+        List<UserContext> userContexts = getUserContexts(existingSession, authenticatedUser, credentials);
 
         // Update existing session, if it exists
         String authToken;


### PR DESCRIPTION
The `updateUserContext()` function of `AuthenticationProvider` has existed for a while, but it was written under the assumption that `AuthenticatedUser` will always receive an updated set of credentials, thus the possibly-updated `UserContext` will be able to access this information.

This is false. The `AuthenticatedUser` will only be updated if `updateAuthenticatedUser()` does so, and relying on that is bad. There's not much for `updateUserContext()` to update with if it can't be guaranteed access to fresh information.

Updating `UserContext` may require peeking at the most recent HTTP request / credentials, so the most recent `Credentials` object should be passed to `updateUserContext()` as well.