### PR TITLE
GUACAMOLE-5: Fix identifier validity regression.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ObjectModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ObjectModel.java
@@ -19,9 +19,6 @@
 
 package org.apache.guacamole.auth.jdbc.base;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 /**
  * Object representation of a Guacamole object, such as a user or connection,
  * as represented in the database.
@@ -85,62 +82,6 @@ public abstract class ObjectModel {
      */
     public void setObjectID(Integer objectID) {
         this.objectID = objectID;
-    }
-
-    /**
-     * Returns whether the given string is a valid identifier within the JDBC
-     * authentication extension. Invalid identifiers may result in SQL errors
-     * from the underlying database when used in queries.
-     *
-     * @param identifier
-     *     The string to check for validity.
-     *
-     * @return
-     *     true if the given string is a valid identifier, false otherwise.
-     */
-    public static boolean isValidIdentifier(String identifier) {
-
-        // Empty identifiers are invalid
-        if (identifier.isEmpty())
-            return false;
-
-        // Identifier is invalid if any non-numeric characters are present
-        for (int i = 0; i < identifier.length(); i++) {
-            if (!Character.isDigit(identifier.charAt(i)))
-                return false;
-        }
-
-        // Identifier is valid - contains only numeric characters
-        return true;
-
-    }
-
-    /**
-     * Filters the given collection of strings, returning a new collection
-     * containing only those strings which are valid identifiers. If no strings
-     * within the collection are valid identifiers, the returned collection will
-     * simply be empty.
-     *
-     * @param identifiers
-     *     The collection of strings to filter.
-     *
-     * @return
-     *     A new collection containing only the strings within the provided
-     *     collection which are valid identifiers.
-     */
-    public static Collection<String> filterIdentifiers(Collection<String> identifiers) {
-
-        // Obtain enough space for a full copy of the given identifiers
-        Collection<String> validIdentifiers = new ArrayList<String>(identifiers.size());
-
-        // Add only valid identifiers to the copy
-        for (String identifier : identifiers) {
-            if (ObjectModel.isValidIdentifier(identifier))
-                validIdentifiers.add(identifier);
-        }
-
-        return validIdentifiers;
-
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -258,6 +258,14 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
     }
 
+    @Override
+    protected boolean isValidIdentifier(String identifier) {
+
+        // All strings are valid user identifiers
+        return true;
+
+    }
+
     /**
      * Retrieves the user corresponding to the given credentials from the
      * database. If the user account is expired, and the credentials contain


### PR DESCRIPTION
Pull request #38 introduced a regression which made it impossible to retrieve specific users. This is because the assumption driving #38 (that all identifiers within the JDBC auth are numeric strings) is incorrect. `User` objects within the JDBC auth have pure string identifiers which are not derived from internal numeric IDs and need not be numeric.

This change moves the validity checking from the base `ObjectModel` class into the object-specific `ModeledDirectoryObjectService` class, such that the `Directory` implementation itself can override the default numeric-only behavior if the objects truly do not require numeric identifiers.
