### PR TITLE
GUACAMOLE-5: Add support for managing sharing profile permissions.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/APIConnection.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/APIConnection.java
@@ -19,12 +19,14 @@
 
 package org.apache.guacamole.rest.connection;
 
+import java.util.Collection;
 import java.util.Map;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
+import org.apache.guacamole.rest.sharingprofile.APISharingProfile;
 
 /**
  * A simple connection to expose through the REST endpoints.
@@ -64,6 +66,12 @@ public class APIConnection {
      * Map of all associated attributes by attribute identifier.
      */
     private Map<String, String> attributes;
+
+    /**
+     * All associated sharing profiles. If sharing profiles are not being
+     * queried, this may be omitted.
+     */
+    private Collection<APISharingProfile> sharingProfiles;
 
     /**
      * The count of currently active connections using this connection.
@@ -225,6 +233,30 @@ public class APIConnection {
      */
     public void setAttributes(Map<String, String> attributes) {
         this.attributes = attributes;
+    }
+
+    /**
+     * Returns a collection of all associated sharing profiles, or null if
+     * sharing profiles have not been queried.
+     *
+     * @return
+     *     A collection of all associated sharing profiles, or null if sharing
+     *     profiles have not been queried.
+     */
+    public Collection<APISharingProfile> getSharingProfiles() {
+        return sharingProfiles;
+    }
+
+    /**
+     * Sets the collection of all associated sharing profiles to the given
+     * collection, which may be null if sharing profiles have not been queried.
+     *
+     * @param sharingProfiles
+     *     The collection containing all sharing profiles associated with this
+     *     connection, or null if sharing profiles have not been queried.
+     */
+    public void setSharingProfiles(Collection<APISharingProfile> sharingProfiles) {
+        this.sharingProfiles = sharingProfiles;
     }
 
 }

--- a/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
+++ b/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
@@ -68,6 +68,17 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
             connectionGroupTemplate : '=',
 
             /**
+             * The URL or ID of the Angular template to use when rendering a
+             * sharing profile. The @link{GroupListItem} associated with that
+             * sharing profile will be exposed within the scope of the template
+             * as <code>item</code>, and the arbitrary context object, if any,
+             * will be exposed as <code>context</code>.
+             *
+             * @type String
+             */
+            sharingProfileTemplate : '=',
+
+            /**
              * Whether the root of the connection group hierarchy given should
              * be shown. If false (the default), only the descendants of the
              * given connection group will be listed.
@@ -165,6 +176,22 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                 return item.isConnectionGroup && !!$scope.connectionGroupTemplate;
             };
 
+            /**
+             * Returns whether the given item represents a sharing profile that
+             * can be displayed. If there is no sharing profile template, then
+             * no sharing profile is visible.
+             *
+             * @param {GroupListItem} item
+             *     The item to check.
+             *
+             * @returns {Boolean}
+             *     true if the given item is a sharing profile that can be
+             *     displayed, false otherwise.
+             */
+            $scope.isVisibleSharingProfile = function isVisibleSharingProfile(item) {
+                return item.isSharingProfile && !!$scope.sharingProfileTemplate;
+            };
+
             // Set contents whenever the connection group is assigned or changed
             $scope.$watch('connectionGroups', function setContents(connectionGroups) {
 
@@ -185,7 +212,8 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
 
                         // Create root item for current connection group
                         var rootItem = GroupListItem.fromConnectionGroup(dataSource, connectionGroup,
-                            !!$scope.connectionTemplate, countActiveConnections);
+                            !!$scope.connectionTemplate, !!$scope.sharingProfileTemplate,
+                            countActiveConnections);
 
                         // If root group is to be shown, add it as a root item
                         if ($scope.showRootGroup)

--- a/guacamole/src/main/webapp/app/groupList/templates/guacGroupList.html
+++ b/guacamole/src/main/webapp/app/groupList/templates/guacGroupList.html
@@ -1,38 +1,60 @@
 <div class="group-list">
 
-    <script type="text/ng-template" id="nestedGroup.html">
+    <script type="text/ng-template" id="nestedItem.html">
 
         <!-- Connection -->
-        <div class="connection" ng-show="isVisibleConnection(item)">
+        <div class="connection expandable" ng-if="isVisibleConnection(item)"
+            ng-class="{expanded: item.isExpanded, empty: !item.children.length}">
             <div class="caption">
+
+                <!-- Expand/collapse icon -->
+                <div class="icon expand" ng-click="toggleExpanded(item)"
+                    ng-if="sharingProfileTemplate"></div>
+
                 <ng-include src="connectionTemplate"/>
+
             </div>
+
+            <!-- Children of this connection -->
+            <div class="children" ng-show="item.isExpanded">
+                <div class="list-item" ng-repeat="item in item.children | orderBy : 'name'"
+                    ng-include="'nestedItem.html'"></div>
+            </div>
+
         </div>
 
         <!-- Connection group -->
-        <div class="group" ng-show="isVisibleConnectionGroup(item)">
+        <div class="group expandable" ng-if="isVisibleConnectionGroup(item)"
+            ng-class="{expanded: item.isExpanded, empty: !item.children.length, balancer: item.isBalancing}">
             <div class="caption">
 
-                <!-- Connection group icon -->
-                <div class="icon group type" ng-click="toggleExpanded(item)"
-                     ng-class="{expanded: item.isExpanded, empty: !item.children.length, balancer: item.isBalancing}"></div>
+                <!-- Expand/collapse icon -->
+                <div class="icon expand" ng-click="toggleExpanded(item)"></div>
 
                 <ng-include src="connectionGroupTemplate"/>
 
             </div>
 
             <!-- Children of this group -->
-            <div class="children" ng-show="item.isExpanded">
-                <div class="list-item" ng-repeat="item in item.children | orderBy : 'name'" ng-include="'nestedGroup.html'">
+            <div class="children" ng-if="item.isExpanded">
+                <div class="list-item" ng-repeat="item in item.children | orderBy : 'name'"
+                    ng-include="'nestedItem.html'"></div>
             </div>
 
+        </div>
+
+        <!-- Sharing profile -->
+        <div class="sharing-profile" ng-show="isVisibleSharingProfile(item)">
+            <div class="caption">
+                <ng-include src="sharingProfileTemplate"/>
+            </div>
         </div>
 
     </script>
 
     <!-- Root-level connections / groups -->
     <div class="group-list-page">
-        <div class="list-item" ng-repeat="item in childrenPage" ng-include="'nestedGroup.html'"></div>
+        <div class="list-item" ng-repeat="item in childrenPage" ng-include="'nestedItem.html'"></div>
     </div>
 
     <!-- Pager for connections / groups -->

--- a/guacamole/src/main/webapp/app/home/templates/connection.html
+++ b/guacamole/src/main/webapp/app/home/templates/connection.html
@@ -1,19 +1,15 @@
-<a ng-href="#/client/{{context.getClientIdentifier(item)}}">
+<a ng-href="#/client/{{context.getClientIdentifier(item)}}"
+   ng-class="{active: item.getActiveConnections()}">
 
-    <div class="caption" ng-class="{active: item.getActiveConnections()}">
+    <!-- Connection icon -->
+    <div class="icon type" ng-class="item.protocol"></div>
 
-        <!-- Connection icon -->
-        <div class="protocol">
-            <div class="icon type" ng-class="item.protocol"></div>
-        </div>
+    <!-- Connection name -->
+    <span class="name">{{item.name}}</span>
 
-        <!-- Connection name -->
-        <span class="name">{{item.name}}</span>
-        
-        <!-- Active user count -->
-        <span class="activeUserCount" ng-show="item.getActiveConnections()"
-            translate="HOME.INFO_ACTIVE_USER_COUNT"
-            translate-values="{USERS: item.getActiveConnections()}"></span>
+    <!-- Active user count -->
+    <span class="activeUserCount" ng-show="item.getActiveConnections()"
+        translate="HOME.INFO_ACTIVE_USER_COUNT"
+        translate-values="{USERS: item.getActiveConnections()}"></span>
 
-    </div>
 </a>

--- a/guacamole/src/main/webapp/app/index/styles/lists.css
+++ b/guacamole/src/main/webapp/app/index/styles/lists.css
@@ -44,28 +44,21 @@
     color: black;
 }
 
-.connection:hover {
+.recent-connections .connection:hover {
     background: #CDA;
 }
 
-.connection .thumbnail {
+.recent-connections .connection .thumbnail {
+    display: block;
     margin: 0.5em;
 }
 
-.connection .thumbnail > * {
+.recent-connections .connection .thumbnail > * {
     border: 1px solid black;
     background: black;
     box-shadow: 1px 1px 5px black;
     max-width: 75%;
     display: inline-block;
-}
-
-div.recent-connections .connection .thumbnail {
-    display: block;
-}
-
-div.recent-connections .protocol {
-    display: none;
 }
 
 .caption * {

--- a/guacamole/src/main/webapp/app/index/styles/ui.css
+++ b/guacamole/src/main/webapp/app/index/styles/ui.css
@@ -164,14 +164,11 @@ div.section {
     background-image: url('images/action-icons/guac-monitor-add.png');
 }
 
-.protocol {
+.connection .icon,
+.connection-group .icon {
     display: inline-block;
-}
-
-.protocol .icon {
     width: 24px;
     height: 24px;
-    background-image: url('images/protocol-icons/guac-plug.png');
     background-size: 16px 16px;
     -moz-background-size: 16px 16px;
     -webkit-background-size: 16px 16px;
@@ -180,44 +177,57 @@ div.section {
     background-position: center center;
 }
 
-.protocol .icon.ssh,
-.protocol .icon.telnet {
+.group .icon {
+    background-image: url('images/folder-closed.png');
+}
+
+.group.expanded .icon {
+    background-image: url('images/folder-open.png');
+}
+
+.connection .icon {
+    background-image: url('images/protocol-icons/guac-plug.png');
+}
+
+.connection .icon.ssh,
+.connection .icon.telnet {
     background-image: url('images/protocol-icons/guac-text.png');
 }
 
-.protocol .icon.vnc,
-.protocol .icon.rdp {
+.connection .icon.vnc,
+.connection .icon.rdp {
     background-image: url('images/protocol-icons/guac-monitor.png');
 }
+
 /*
  * Groups
  */
 
-.group > .children {
+.expandable > .children {
     margin-left: 13px;
-    padding-left: 6px;
+    padding-left: 13px;
 }
  
-.group .icon.group.type.empty.balancer {
+.group.empty.balancer .icon {
     opacity: 1;
     background-image: url('images/protocol-icons/guac-monitor.png');
 }
 
-.group.expanded > .children {
+.expandable.expanded > .children {
     display: block;
     border-left: 1px dotted rgba(0, 0, 0, 0.25);
 }
 
-.group > .caption .icon.group {
+.expandable > .caption .icon.expand {
     opacity: 0.75;
     background-image: url('images/group-icons/guac-closed.png');
 }
 
-.group .icon.type.group.expanded {
+.expandable.expanded .icon.expand {
     background-image: url('images/group-icons/guac-open.png');
 }
 
-.group .icon.type.group.empty {
+.expandable.empty .icon.expand {
     opacity: 0.25;
     background-image: url('images/group-icons/guac-open.png');
 }

--- a/guacamole/src/main/webapp/app/index/styles/ui.css
+++ b/guacamole/src/main/webapp/app/index/styles/ui.css
@@ -178,11 +178,11 @@ div.section {
     background-position: center center;
 }
 
-.group .icon {
+.group > .caption .icon {
     background-image: url('images/folder-closed.png');
 }
 
-.group.expanded .icon {
+.group.expanded > .caption .icon {
     background-image: url('images/folder-open.png');
 }
 
@@ -253,11 +253,11 @@ div.section {
     background-image: url('images/group-icons/guac-closed.png');
 }
 
-.expandable.expanded .icon.expand {
+.expandable.expanded > .caption .icon.expand {
     background-image: url('images/group-icons/guac-open.png');
 }
 
-.expandable.empty .icon.expand {
+.expandable.empty > .caption .icon.expand {
     opacity: 0.25;
     background-image: url('images/group-icons/guac-open.png');
 }

--- a/guacamole/src/main/webapp/app/index/styles/ui.css
+++ b/guacamole/src/main/webapp/app/index/styles/ui.css
@@ -165,7 +165,8 @@ div.section {
 }
 
 .connection .icon,
-.connection-group .icon {
+.connection-group .icon,
+.sharing-profile .icon {
     display: inline-block;
     width: 24px;
     height: 24px;
@@ -197,6 +198,10 @@ div.section {
 .connection .icon.vnc,
 .connection .icon.rdp {
     background-image: url('images/protocol-icons/guac-monitor.png');
+}
+
+.sharing-profile .icon {
+    background-image: url('images/share.png');
 }
 
 /*

--- a/guacamole/src/main/webapp/app/index/styles/ui.css
+++ b/guacamole/src/main/webapp/app/index/styles/ui.css
@@ -214,17 +214,42 @@ div.section {
 }
  
 .group.empty.balancer .icon {
-    opacity: 1;
     background-image: url('images/protocol-icons/guac-monitor.png');
 }
 
-.expandable.expanded > .children {
+.expandable.expanded > .children > .list-item {
+    position: relative;
+}
+
+.expandable.expanded > .children > .list-item:before,
+.expandable.expanded > .children > .list-item:after {
     display: block;
-    border-left: 1px dotted rgba(0, 0, 0, 0.25);
+    content: ' ';
+    position: absolute;
+    z-index: -1;
+}
+
+.expandable.expanded > .children > .list-item:before {
+    border-left: 1px solid #BBB;
+    left: -13px;
+    top: -0.75em;
+    bottom: 0;
+}
+
+.expandable.expanded > .children > .list-item:last-child:before {
+    height: 1.5em;
+}
+
+.expandable.expanded > .children > .list-item:after {
+    display: block;
+    content: ' ';
+    border-bottom: 1px solid #BBB;
+    left: -13px;
+    width: 13px;
+    top: 0.75em;
 }
 
 .expandable > .caption .icon.expand {
-    opacity: 0.75;
     background-image: url('images/group-icons/guac-closed.png');
 }
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -709,10 +709,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     $scope.systemPermissionChanged = function systemPermissionChanged(type) {
 
         // Determine current permission setting
-        var value = $scope.permissionFlags.systemPermissions[type];
+        var granted = $scope.permissionFlags.systemPermissions[type];
 
         // Add/remove permission depending on flag state
-        if (value)
+        if (granted)
             addSystemPermission(type);
         else
             removeSystemPermission(type);
@@ -779,10 +779,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     $scope.userPermissionChanged = function userPermissionChanged(type, identifier) {
 
         // Determine current permission setting
-        var value = $scope.permissionFlags.userPermissions[type][identifier];
+        var granted = $scope.permissionFlags.userPermissions[type][identifier];
 
         // Add/remove permission depending on flag state
-        if (value)
+        if (granted)
             addUserPermission(type, identifier);
         else
             removeUserPermission(type, identifier);
@@ -931,10 +931,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         connectionPermissionChanged : function connectionPermissionChanged(identifier) {
 
             // Determine current permission setting
-            var value = $scope.permissionFlags.connectionPermissions.READ[identifier];
+            var granted = $scope.permissionFlags.connectionPermissions.READ[identifier];
 
             // Add/remove permission depending on flag state
-            if (value)
+            if (granted)
                 addConnectionPermission(identifier);
             else
                 removeConnectionPermission(identifier);
@@ -953,10 +953,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         connectionGroupPermissionChanged : function connectionGroupPermissionChanged(identifier) {
 
             // Determine current permission setting
-            var value = $scope.permissionFlags.connectionGroupPermissions.READ[identifier];
+            var granted = $scope.permissionFlags.connectionGroupPermissions.READ[identifier];
 
             // Add/remove permission depending on flag state
-            if (value)
+            if (granted)
                 addConnectionGroupPermission(identifier);
             else
                 removeConnectionGroupPermission(identifier);
@@ -975,10 +975,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         sharingProfilePermissionChanged : function sharingProfilePermissionChanged(identifier) {
 
             // Determine current permission setting
-            var value = $scope.permissionFlags.sharingProfilePermissions.READ[identifier];
+            var granted = $scope.permissionFlags.sharingProfilePermissions.READ[identifier];
 
             // Add/remove permission depending on flag state
-            if (value)
+            if (granted)
                 addSharingProfilePermission(identifier);
             else
                 removeSharingProfilePermission(identifier);

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -633,6 +633,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         {
             label: "MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS",
             value: PermissionSet.SystemPermissionType.CREATE_CONNECTION_GROUP
+        },
+        {
+            label: "MANAGE_USER.FIELD_HEADER_CREATE_NEW_SHARING_PROFILES",
+            value: PermissionSet.SystemPermissionType.CREATE_SHARING_PROFILE
         }
     ];
 
@@ -861,6 +865,45 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
 
     };
 
+    /**
+     * Updates the permissionsAdded and permissionsRemoved permission sets to
+     * reflect the addition of the given sharing profile permission.
+     *
+     * @param {String} identifier
+     *     The identifier of the sharing profile to add READ permission for.
+     */
+    var addSharingProfilePermission = function addSharingProfilePermission(identifier) {
+
+        // If permission was previously removed, simply un-remove it
+        if (PermissionSet.hasSharingProfilePermission(permissionsRemoved, PermissionSet.ObjectPermissionType.READ, identifier))
+            PermissionSet.removeSharingProfilePermission(permissionsRemoved, PermissionSet.ObjectPermissionType.READ, identifier);
+
+        // Otherwise, explicitly add the permission
+        else
+            PermissionSet.addSharingProfilePermission(permissionsAdded, PermissionSet.ObjectPermissionType.READ, identifier);
+
+    };
+
+    /**
+     * Updates the permissionsAdded and permissionsRemoved permission sets to
+     * reflect the removal of the given sharing profile permission.
+     *
+     * @param {String} identifier
+     *     The identifier of the sharing profile to remove READ permission for.
+     */
+    var removeSharingProfilePermission = function removeSharingProfilePermission(identifier) {
+
+        // If permission was previously added, simply un-add it
+        if (PermissionSet.hasSharingProfilePermission(permissionsAdded, PermissionSet.ObjectPermissionType.READ, identifier))
+            PermissionSet.removeSharingProfilePermission(permissionsAdded, PermissionSet.ObjectPermissionType.READ, identifier);
+
+        // Otherwise, explicitly remove the permission
+        else
+            PermissionSet.addSharingProfilePermission(permissionsRemoved, PermissionSet.ObjectPermissionType.READ, identifier);
+
+    };
+
+
     // Expose permission query and modification functions to group list template
     $scope.groupListContext = {
 
@@ -917,6 +960,28 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
                 addConnectionGroupPermission(identifier);
             else
                 removeConnectionGroupPermission(identifier);
+
+        },
+
+        /**
+         * Notifies the controller that a change has been made to the given
+         * sharing profile permission for the user being edited. This only
+         * applies to READ permissions.
+         *
+         * @param {String} identifier
+         *     The identifier of the sharing profile affected by the changed
+         *     permission.
+         */
+        sharingProfilePermissionChanged : function sharingProfilePermissionChanged(identifier) {
+
+            // Determine current permission setting
+            var value = $scope.permissionFlags.sharingProfilePermissions.READ[identifier];
+
+            // Add/remove permission depending on flag state
+            if (value)
+                addSharingProfilePermission(identifier);
+            else
+                removeSharingProfilePermission(identifier);
 
         }
 

--- a/guacamole/src/main/webapp/app/manage/templates/connectionGroupPermission.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connectionGroupPermission.html
@@ -1,7 +1,13 @@
 <div class="choice">
 
+    <!-- Connection group icon -->
+    <div class="icon type"></div>
+
+    <!-- Permission checkbox -->
     <input type="checkbox" ng-model="context.getPermissionFlags().connectionGroupPermissions.READ[item.identifier]"
                            ng-change="context.connectionGroupPermissionChanged(item.identifier)"/>
 
+    <!-- Connection group name -->
     <span class="name">{{item.name}}</span>
+
 </div>

--- a/guacamole/src/main/webapp/app/manage/templates/connectionPermission.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connectionPermission.html
@@ -1,11 +1,9 @@
 <div class="choice">
 
     <!-- Connection icon -->
-    <div class="protocol">
-        <div class="icon type" ng-class="item.protocol"></div>
-    </div>
+    <div class="icon type" ng-class="item.protocol"></div>
 
-    <!-- Checkbox -->
+    <!-- Permission checkbox -->
     <input type="checkbox" ng-model="context.getPermissionFlags().connectionPermissions.READ[item.identifier]"
                            ng-change="context.connectionPermissionChanged(item.identifier)"/>
 

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -79,6 +79,7 @@
                     context="groupListContext"
                     connection-groups="filteredRootGroups"
                     connection-template="'app/manage/templates/connectionPermission.html'"
+                    sharing-profile-template="'app/manage/templates/sharingProfilePermission.html'"
                     connection-group-template="'app/manage/templates/connectionGroupPermission.html'"
                     page-size="20"/>
             </div>

--- a/guacamole/src/main/webapp/app/manage/templates/sharingProfilePermission.html
+++ b/guacamole/src/main/webapp/app/manage/templates/sharingProfilePermission.html
@@ -1,0 +1,13 @@
+<div class="choice">
+
+    <!-- Sharing profile icon -->
+    <div class="icon type"></div>
+
+    <!-- Permission checkbox -->
+    <input type="checkbox" ng-model="context.getPermissionFlags().sharingProfilePermissions.READ[item.identifier]"
+                           ng-change="context.sharingProfilePermissionChanged(item.identifier)"/>
+
+    <!-- Sharing profile name -->
+    <span class="name">{{item.name}}</span>
+
+</div>

--- a/guacamole/src/main/webapp/app/rest/services/permissionService.js
+++ b/guacamole/src/main/webapp/app/rest/services/permissionService.js
@@ -175,6 +175,10 @@ angular.module('rest').factory('permissionService', ['$injector',
         addObjectPatchOperations(patch, operation, "/connectionGroupPermissions",
             permissions.connectionGroupPermissions);
 
+        // Add sharing profile permission operations to patch
+        addObjectPatchOperations(patch, operation, "/sharingProfilePermissions",
+            permissions.sharingProfilePermissions);
+
         // Add active connection permission operations to patch
         addObjectPatchOperations(patch, operation, "/activeConnectionPermissions",
             permissions.activeConnectionPermissions);

--- a/guacamole/src/main/webapp/app/rest/types/Connection.js
+++ b/guacamole/src/main/webapp/app/rest/types/Connection.js
@@ -95,6 +95,15 @@ angular.module('rest').factory('Connection', [function defineConnection() {
          */
         this.activeConnections = template.activeConnections;
 
+        /**
+         * An array of all associated sharing profiles, if known. This property
+         * may be null or undefined if sharing profiles have not been queried,
+         * and thus the sharing profiles are unknown.
+         *
+         * @type SharingProfile[]
+         */
+        this.sharingProfiles = template.sharingProfiles;
+
     };
 
     return Connection;

--- a/guacamole/src/main/webapp/app/rest/types/PermissionFlagSet.js
+++ b/guacamole/src/main/webapp/app/rest/types/PermissionFlagSet.js
@@ -88,6 +88,25 @@ angular.module('rest').factory('PermissionFlagSet', ['PermissionSet',
         };
 
         /**
+         * The granted state of each permission for each sharing profile, as a
+         * map of object permission type string to permission map. The
+         * permission map is, in turn, a map of sharing profile identifier to
+         * boolean value. A particular permission is granted if its
+         * corresponding boolean value is set to true. Valid permission type
+         * strings are defined within PermissionSet.ObjectPermissionType.
+         * Permissions which are not granted may be set to false, but this is
+         * not required.
+         *
+         * @type Object.<String, Object.<String, Boolean>>
+         */
+        this.sharingProfilePermissions = template.sharingProfilePermissions || {
+            'READ'       : {},
+            'UPDATE'     : {},
+            'DELETE'     : {},
+            'ADMINISTER' : {}
+        };
+
+        /**
          * The granted state of each permission for each active connection, as
          * a map of object permission type string to permission map. The
          * permission map is, in turn, a map of active connection identifier to
@@ -187,6 +206,9 @@ angular.module('rest').factory('PermissionFlagSet', ['PermissionSet',
 
         // Add all granted connection group permissions
         addObjectPermissions(permissionSet.connectionGroupPermissions, permissionFlagSet.connectionGroupPermissions);
+
+        // Add all granted sharing profile permissions
+        addObjectPermissions(permissionSet.sharingProfilePermissions, permissionFlagSet.sharingProfilePermissions);
 
         // Add all granted active connection permissions
         addObjectPermissions(permissionSet.activeConnectionPermissions, permissionFlagSet.activeConnectionPermissions);

--- a/guacamole/src/main/webapp/app/rest/types/PermissionSet.js
+++ b/guacamole/src/main/webapp/app/rest/types/PermissionSet.js
@@ -53,6 +53,15 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
          * @type Object.<String, String[]>
          */
         this.connectionGroupPermissions = template.connectionGroupPermissions || {};
+
+        /**
+         * Map of sharing profile identifiers to the corresponding array of
+         * granted permissions. Each permission is represented by a string
+         * listed within PermissionSet.ObjectPermissionType.
+         *
+         * @type Object.<String, String[]>
+         */
+        this.sharingProfilePermissions = template.sharingProfilePermissions || {};
         
         /**
          * Map of active connection identifiers to the corresponding array of
@@ -132,7 +141,12 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
         /**
          * Permission to create new connection groups.
          */
-        CREATE_CONNECTION_GROUP : "CREATE_CONNECTION_GROUP"
+        CREATE_CONNECTION_GROUP : "CREATE_CONNECTION_GROUP",
+
+        /**
+         * Permission to create new sharing profiles.
+         */
+        CREATE_SHARING_PROFILE : "CREATE_SHARING_PROFILE"
 
     };
 
@@ -245,6 +259,28 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
      */
     PermissionSet.hasConnectionGroupPermission = function hasConnectionGroupPermission(permSet, type, identifier) {
         return hasPermission(permSet.connectionGroupPermissions, type, identifier);
+    };
+
+    /**
+     * Returns whether the given permission is granted for the sharing profile
+     * having the given ID.
+     *
+     * @param {PermissionSet|Object} permSet
+     *     The permission set to check.
+     *
+     * @param {String} type
+     *     The permission to search for, as defined by
+     *     PermissionSet.ObjectPermissionType.
+     *
+     * @param {String} identifier
+     *     The identifier of the sharing profile to which the permission
+     *     applies.
+     *
+     * @returns {Boolean}
+     *     true if the permission is present (granted), false otherwise.
+     */
+    PermissionSet.hasSharingProfilePermission = function hasSharingProfilePermission(permSet, type, identifier) {
+        return hasPermission(permSet.sharingProfilePermissions, type, identifier);
     };
 
     /**
@@ -546,6 +582,56 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
     PermissionSet.removeConnectionGroupPermission = function removeConnectionGroupPermission(permSet, type, identifier) {
         permSet.connectionGroupPermissions = permSet.connectionGroupPermissions || {};
         return removeObjectPermission(permSet.connectionGroupPermissions, type, identifier);
+    };
+
+    /**
+     * Adds the given sharing profile permission applying to the sharing profile
+     * with the given ID to the given permission set, if not already present. If
+     * the permission is already present, this function has no effect.
+     *
+     * @param {PermissionSet} permSet
+     *     The permission set to modify.
+     *
+     * @param {String} type
+     *     The permission to add, as defined by
+     *     PermissionSet.ObjectPermissionType.
+     *
+     * @param {String} identifier
+     *     The identifier of the sharing profile to which the permission
+     *     applies.
+     *
+     * @returns {Boolean}
+     *     true if the permission was added, false if the permission was
+     *     already present in the given permission set.
+     */
+    PermissionSet.addSharingProfilePermission = function addSharingProfilePermission(permSet, type, identifier) {
+        permSet.sharingProfilePermissions = permSet.sharingProfilePermissions || {};
+        return addObjectPermission(permSet.sharingProfilePermissions, type, identifier);
+    };
+
+    /**
+     * Removes the given sharing profile permission applying to the sharing
+     * profile with the given ID from the given permission set, if present. If
+     * the permission is not present, this function has no effect.
+     *
+     * @param {PermissionSet} permSet
+     *     The permission set to modify.
+     *
+     * @param {String} type
+     *     The permission to remove, as defined by
+     *     PermissionSet.ObjectPermissionType.
+     *
+     * @param {String} identifier
+     *     The identifier of the sharing profile to which the permission
+     *     applies.
+     *
+     * @returns {Boolean}
+     *     true if the permission was removed, false if the permission was not
+     *     present in the given permission set.
+     */
+    PermissionSet.removeSharingProfilePermission = function removeSharingProfilePermission(permSet, type, identifier) {
+        permSet.sharingProfilePermissions = permSet.sharingProfilePermissions || {};
+        return removeObjectPermission(permSet.sharingProfilePermissions, type, identifier);
     };
 
     /**

--- a/guacamole/src/main/webapp/app/settings/templates/connection.html
+++ b/guacamole/src/main/webapp/app/settings/templates/connection.html
@@ -1,19 +1,15 @@
-<a ng-href="#/manage/{{item.dataSource}}/connections/{{item.identifier}}">
+<a ng-href="#/manage/{{item.dataSource}}/connections/{{item.identifier}}"
+   ng-class="{active: item.getActiveConnections()}">
 
-    <div class="caption" ng-class="{active: item.getActiveConnections()}">
+    <!-- Connection icon -->
+    <div class="icon type" ng-class="item.protocol"></div>
 
-        <!-- Connection icon -->
-        <div class="protocol">
-            <div class="icon type" ng-class="item.protocol"></div>
-        </div>
+    <!-- Connection name -->
+    <span class="name">{{item.name}}</span>
 
-        <!-- Connection name -->
-        <span class="name">{{item.name}}</span>
+    <!-- Active user count -->
+    <span class="activeUserCount" ng-show="item.getActiveConnections()"
+        translate="SETTINGS_CONNECTIONS.INFO_ACTIVE_USER_COUNT"
+        translate-values="{USERS: item.getActiveConnections()}"></span>
 
-        <!-- Active user count -->
-        <span class="activeUserCount" ng-show="item.getActiveConnections()"
-            translate="SETTINGS_CONNECTIONS.INFO_ACTIVE_USER_COUNT"
-            translate-values="{USERS: item.getActiveConnections()}"></span>
-        
-    </div>
 </a>

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -256,6 +256,7 @@
         "FIELD_HEADER_CREATE_NEW_USERS"              : "Create new users:",
         "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "Create new connections:",
         "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "Create new connection groups:",
+        "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"   : "Create new sharing profiles:",
         "FIELD_HEADER_PASSWORD"                      : "@:APP.FIELD_HEADER_PASSWORD",
         "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
         "FIELD_HEADER_USERNAME"                      : "Username:",


### PR DESCRIPTION
Though previous changes did add support within the REST API for management of sharing profile permissions, such support remained absent in the admin interface.

This change adds support for managing sharing profile permissions on a per-user basis, as well as granting/revoking the system-level permission for creating sharing profiles. Management of sharing profile permissions is handled within the same hierarchical tree previously used only for connections and connection groups, handling the sharing profiles associated with a connection as if they were the connections within a group:

![sharing-profile-permission-management](https://cloud.githubusercontent.com/assets/4632905/17424702/65bae26c-5a7b-11e6-96ac-e3830e13bead.png)

To make the tree more readable, I altered the rendering of the tree lines such that they have the traditional right-angle bends and terminate at the rough midpoint of each list item. This style is inherited by the other parts of the interface which use the `guacGroupList` directive, including the home screen and the location chooser (the dropdown used within the management interface for selecting a parent connection group).

These changes also required altering the connection group tree REST resource such that it includes sharing profiles within the tree.