### PR TITLE
GUACAMOLE-5: Add missing sharing profile REST services.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
@@ -100,6 +100,26 @@ public class SchemaResource {
     }
 
     /**
+     * Retrieves the possible attributes of a sharing profile object.
+     *
+     * @return
+     *     A collection of forms which describe the possible attributes of a
+     *     sharing profile object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the possible attributes.
+     */
+    @GET
+    @Path("sharingProfileAttributes")
+    public Collection<Form> getSharingProfileAttributes()
+            throws GuacamoleException {
+
+        // Retrieve all possible sharing profile attributes
+        return userContext.getSharingProfileAttributes();
+
+    }
+
+    /**
      * Retrieves the possible attributes of a connection group object.
      *
      * @return

--- a/guacamole/src/main/webapp/app/rest/services/schemaService.js
+++ b/guacamole/src/main/webapp/app/rest/services/schemaService.js
@@ -100,6 +100,40 @@ angular.module('rest').factory('schemaService', ['$injector',
 
     /**
      * Makes a request to the REST API to get the list of available attributes
+     * for sharing profile objects, returning a promise that provides an array
+     * of @link{Form} objects if successful. Each element of the array describes
+     * a logical grouping of possible attributes.
+     *
+     * @param {String} dataSource
+     *     The unique identifier of the data source containing the sharing
+     *     profiles whose available attributes are to be retrieved. This
+     *     identifier corresponds to an AuthenticationProvider within the
+     *     Guacamole web application.
+     *
+     * @returns {Promise.<Form[]>}
+     *     A promise which will resolve with an array of @link{Form}
+     *     objects, where each @link{Form} describes a logical grouping of
+     *     possible attributes.
+     */
+    service.getSharingProfileAttributes = function getSharingProfileAttributes(dataSource) {
+
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // Retrieve available sharing profile attributes
+        return $http({
+            cache   : cacheService.schema,
+            method  : 'GET',
+            url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/schema/sharingProfileAttributes',
+            params  : httpParameters
+        });
+
+    };
+
+    /**
+     * Makes a request to the REST API to get the list of available attributes
      * for connection group objects, returning a promise that provides an array
      * of @link{Form} objects if successful. Each element of the array
      * a logical grouping of possible attributes.

--- a/guacamole/src/main/webapp/app/rest/services/sharingProfileService.js
+++ b/guacamole/src/main/webapp/app/rest/services/sharingProfileService.js
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Service for operating on sharing profiles via the REST API.
+ */
+angular.module('rest').factory('sharingProfileService', ['$injector',
+        function sharingProfileService($injector) {
+
+    // Required services
+    var $http                 = $injector.get('$http');
+    var authenticationService = $injector.get('authenticationService');
+    var cacheService          = $injector.get('cacheService');
+    
+    var service = {};
+    
+    /**
+     * Makes a request to the REST API to get a single sharing profile,
+     * returning a promise that provides the corresponding @link{SharingProfile}
+     * if successful.
+     * 
+     * @param {String} id The ID of the sharing profile.
+     * 
+     * @returns {Promise.<SharingProfile>}
+     *     A promise which will resolve with a @link{SharingProfile} upon
+     *     success.
+     * 
+     * @example
+     * 
+     * sharingProfileService.getSharingProfile('mySharingProfile').success(function(sharingProfile) {
+     *     // Do something with the sharing profile
+     * });
+     */
+    service.getSharingProfile = function getSharingProfile(dataSource, id) {
+
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // Retrieve sharing profile
+        return $http({
+            cache   : cacheService.connections,
+            method  : 'GET',
+            url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/sharingProfiles/' + encodeURIComponent(id),
+            params  : httpParameters
+        });
+
+    };
+
+    /**
+     * Makes a request to the REST API to get the parameters of a single
+     * sharing profile, returning a promise that provides the corresponding
+     * map of parameter name/value pairs if successful.
+     * 
+     * @param {String} id
+     *     The identifier of the sharing profile.
+     * 
+     * @returns {Promise.<Object.<String, String>>}
+     *     A promise which will resolve with an map of parameter name/value
+     *     pairs upon success.
+     */
+    service.getSharingProfileParameters = function getSharingProfileParameters(dataSource, id) {
+
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // Retrieve sharing profile parameters
+        return $http({
+            cache   : cacheService.connections,
+            method  : 'GET',
+            url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/sharingProfiles/' + encodeURIComponent(id) + '/parameters',
+            params  : httpParameters
+        });
+ 
+    };
+
+    /**
+     * Makes a request to the REST API to save a sharing profile, returning a
+     * promise that can be used for processing the results of the call. If the
+     * sharing profile is new, and thus does not yet have an associate
+     * identifier, the identifier will be automatically set in the provided
+     * sharing profile upon success.
+     * 
+     * @param {SharingProfile} sharingProfile
+     *     The sharing profile to update.
+     *                          
+     * @returns {Promise}
+     *     A promise for the HTTP call which will succeed if and only if the
+     *     save operation is successful.
+     */
+    service.saveSharingProfile = function saveSharingProfile(dataSource, sharingProfile) {
+        
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // If sharing profile is new, add it and set the identifier automatically
+        if (!sharingProfile.identifier) {
+            return $http({
+                method  : 'POST',
+                url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/sharingProfiles',
+                params  : httpParameters,
+                data    : sharingProfile
+            })
+
+            // Set the identifier on the new sharing profile and clear the cache
+            .success(function sharingProfileCreated(newSharingProfile){
+                sharingProfile.identifier = newSharingProfile.identifier;
+                cacheService.connections.removeAll();
+            });
+        }
+
+        // Otherwise, update the existing sharing profile
+        else {
+            return $http({
+                method  : 'PUT',
+                url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/sharingProfiles/' + encodeURIComponent(sharingProfile.identifier),
+                params  : httpParameters,
+                data    : sharingProfile
+            })
+            
+            // Clear the cache
+            .success(function sharingProfileUpdated(){
+                cacheService.connections.removeAll();
+            });
+        }
+
+    };
+    
+    /**
+     * Makes a request to the REST API to delete a sharing profile,
+     * returning a promise that can be used for processing the results of the call.
+     * 
+     * @param {SharingProfile} sharingProfile
+     *     The sharing profile to delete.
+     *                          
+     * @returns {Promise}
+     *     A promise for the HTTP call which will succeed if and only if the
+     *     delete operation is successful.
+     */
+    service.deleteSharingProfile = function deleteSharingProfile(dataSource, sharingProfile) {
+
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // Delete sharing profile
+        return $http({
+            method  : 'DELETE',
+            url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/sharingProfiles/' + encodeURIComponent(sharingProfile.identifier),
+            params  : httpParameters
+        })
+
+        // Clear the cache
+        .success(function sharingProfileDeleted(){
+            cacheService.connections.removeAll();
+        });
+
+    };
+    
+    return service;
+}]);


### PR DESCRIPTION
This changes adds the missing REST resource for sharing profile attributes, and implements JavaScript services/functions for accessing all sharing-profile-related REST resources.