### PR TITLE
GUACAMOLE-5: Fix targeting of share tag HTML patch.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/html/shared-connection.html
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/html/shared-connection.html
@@ -1,4 +1,4 @@
-<meta name="after" content=".caption .activeUserCount">
+<meta name="after-children" content=".home-connection">
 
 <!-- The user sharing this connection (if any) -->
 <span class="jdbc-share-tag" ng-show="item.wrappedItem.attributes['jdbc-shared-by']"

--- a/guacamole/src/main/webapp/app/home/templates/connection.html
+++ b/guacamole/src/main/webapp/app/home/templates/connection.html
@@ -1,4 +1,5 @@
-<a ng-href="#/client/{{context.getClientIdentifier(item)}}"
+<a class="home-connection"
+   ng-href="#/client/{{context.getClientIdentifier(item)}}"
    ng-class="{active: item.getActiveConnections()}">
 
     <!-- Connection icon -->

--- a/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
+++ b/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
@@ -1,4 +1,4 @@
-<span class="name">
+<span class="home-connection-group name">
     <a ng-show="item.balancing" ng-href="#/client/{{context.getClientIdentifier(item)}}">{{item.name}}</a>
     <span ng-show="!item.balancing">{{item.name}}</span>
 </span>


### PR DESCRIPTION
Recent changes to the HTML structure of connections displayed by `guacGroupList` within the home screen broke the nifty new share tag (the CSS selector within the patch no longer matched).

This change switches to more predictable and specific CSS classes within the home screen's `guacGroupList`, and simplifies the selector in question.