### PR TITLE
GUACAMOLE-72: Sharing profile parameters are stored under "sharingProfileForms", not "forms".

### DIFF
--- a/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
@@ -29,7 +29,7 @@
     <h2 class="header">{{'MANAGE_SHARING_PROFILE.SECTION_HEADER_PARAMETERS' | translate}}</h2>
     <div class="section connection-parameters" ng-class="{loading: !parameters}">
         <guac-form namespace="getNamespace(primaryConnection.protocol)"
-                   content="protocols[primaryConnection.protocol].forms"
+                   content="protocols[primaryConnection.protocol].sharingProfileForms"
                    model="parameters"></guac-form>
     </div>
 


### PR DESCRIPTION
The old `forms` property was split into `connectionForms` and `sharingProfileForms` recently, but this line somehow remains unchanged, resulting in a total lack of parameters when editing a sharing profile.