### PR TITLE
GUACAMOLE-75: Do not insert duplicate permissions.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/ConnectionGroupPermissionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/ConnectionGroupPermissionMapper.xml
@@ -105,12 +105,25 @@
             permission,
             connection_group_id
         )
-        VALUES
-            <foreach collection="permissions" item="permission" separator=",">
-                (#{permission.userID,jdbcType=INTEGER},
-                 #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type,
-                 #{permission.objectIdentifier,jdbcType=INTEGER}::integer)
+        SELECT DISTINCT
+            permissions.user_id,
+            permissions.permission,
+            permissions.connection_group_id
+        FROM
+            <foreach collection="permissions" item="permission"
+                     open="(" separator="UNION ALL" close=")">
+                SELECT #{permission.userID,jdbcType=INTEGER}                                 AS user_id,
+                       #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type AS permission,
+                       #{permission.objectIdentifier,jdbcType=INTEGER}::integer              AS connection_group_id
             </foreach>
+        AS permissions
+        WHERE (user_id, permission, connection_group_id) NOT IN (
+            SELECT
+                guacamole_connection_group_permission.user_id,
+                guacamole_connection_group_permission.permission,
+                guacamole_connection_group_permission.connection_group_id
+            FROM guacamole_connection_group_permission
+        );
 
     </insert>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/ConnectionPermissionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/ConnectionPermissionMapper.xml
@@ -105,12 +105,25 @@
             permission,
             connection_id
         )
-        VALUES
-            <foreach collection="permissions" item="permission" separator=",">
-                (#{permission.userID,jdbcType=INTEGER},
-                 #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type,
-                 #{permission.objectIdentifier,jdbcType=INTEGER}::integer)
+        SELECT DISTINCT
+            permissions.user_id,
+            permissions.permission,
+            permissions.connection_id
+        FROM
+            <foreach collection="permissions" item="permission"
+                     open="(" separator="UNION ALL" close=")">
+                SELECT #{permission.userID,jdbcType=INTEGER}                                 AS user_id,
+                       #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type AS permission,
+                       #{permission.objectIdentifier,jdbcType=INTEGER}::integer              AS connection_id
             </foreach>
+        AS permissions
+        WHERE (user_id, permission, connection_id) NOT IN (
+            SELECT
+                guacamole_connection_permission.user_id,
+                guacamole_connection_permission.permission,
+                guacamole_connection_permission.connection_id
+            FROM guacamole_connection_permission
+        );
 
     </insert>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/SharingProfilePermissionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/SharingProfilePermissionMapper.xml
@@ -105,12 +105,25 @@
             permission,
             sharing_profile_id
         )
-        VALUES
-            <foreach collection="permissions" item="permission" separator=",">
-                (#{permission.userID,jdbcType=INTEGER},
-                 #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type,
-                 #{permission.objectIdentifier,jdbcType=INTEGER}::integer)
+        SELECT DISTINCT
+            permissions.user_id,
+            permissions.permission,
+            permissions.sharing_profile_id
+        FROM
+            <foreach collection="permissions" item="permission"
+                     open="(" separator="UNION ALL" close=")">
+                SELECT #{permission.userID,jdbcType=INTEGER}                                 AS user_id,
+                       #{permission.type,jdbcType=VARCHAR}::guacamole_object_permission_type AS permission,
+                       #{permission.objectIdentifier,jdbcType=INTEGER}::integer              AS sharing_profile_id
             </foreach>
+        AS permissions
+        WHERE (user_id, permission, sharing_profile_id) NOT IN (
+            SELECT
+                guacamole_sharing_profile_permission.user_id,
+                guacamole_sharing_profile_permission.permission,
+                guacamole_sharing_profile_permission.sharing_profile_id
+            FROM guacamole_sharing_profile_permission
+        );
 
     </insert>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/SystemPermissionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/SystemPermissionMapper.xml
@@ -79,11 +79,22 @@
             user_id,
             permission
         )
-        VALUES
-            <foreach collection="permissions" item="permission" separator=",">
-                (#{permission.userID,jdbcType=INTEGER},
-                 #{permission.type,jdbcType=VARCHAR}::guacamole_system_permission_type)
+        SELECT DISTINCT
+            permissions.user_id,
+            permissions.permission
+        FROM
+            <foreach collection="permissions" item="permission"
+                     open="(" separator="UNION ALL" close=")">
+                SELECT #{permission.userID,jdbcType=INTEGER}                                 AS user_id,
+                       #{permission.type,jdbcType=VARCHAR}::guacamole_system_permission_type AS permission
             </foreach>
+        AS permissions
+        WHERE (user_id, permission) NOT IN (
+            SELECT
+                guacamole_system_permission.user_id,
+                guacamole_system_permission.permission
+            FROM guacamole_system_permission
+        );
 
     </insert>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/UserPermissionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/permission/UserPermissionMapper.xml
@@ -111,7 +111,11 @@
             permission,
             affected_user_id
         )
-        SELECT permissions.user_id, permissions.permission, guacamole_user.user_id FROM
+        SELECT DISTINCT
+            permissions.user_id,
+            permissions.permission,
+            guacamole_user.user_id
+        FROM
             <foreach collection="permissions" item="permission"
                      open="(" separator="UNION ALL" close=")">
                 SELECT #{permission.userID,jdbcType=INTEGER}                                 AS user_id,
@@ -119,7 +123,14 @@
                        #{permission.objectIdentifier,jdbcType=INTEGER}                       AS username
             </foreach>
         AS permissions
-        JOIN guacamole_user ON guacamole_user.username = permissions.username; 
+        JOIN guacamole_user ON guacamole_user.username = permissions.username
+        WHERE (permissions.user_id, permissions.permission, guacamole_user.user_id) NOT IN (
+            SELECT
+                guacamole_user_permission.user_id,
+                guacamole_user_permission.permission,
+                guacamole_user_permission.affected_user_id
+            FROM guacamole_user_permission
+        );
 
     </insert>
 


### PR DESCRIPTION
While the MySQL permission inserts use `INSERT IGNORE` to ignore any violations of the table-wide unique constraint, the corresponding PostgreSQL inserts do not. PostgreSQL actually does not have such an option, at least not until recently via `ON CONFLICT UPDATE`.

This change rewrites the permission inserts for PostgreSQL such that only non-duplicate tuples are inserted.