### PR TITLE
GUACAMOLE-74: Migrate to URL-safe share keys.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SecureRandomShareKeyGenerator.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/SecureRandomShareKeyGenerator.java
@@ -20,7 +20,6 @@
 package org.apache.guacamole.auth.jdbc.sharing;
 
 import java.security.SecureRandom;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * An implementation of the ShareKeyGenerator which uses SecureRandom to
@@ -28,18 +27,41 @@ import javax.xml.bind.DatatypeConverter;
  * 
  * @author Michael Jumper
  */
-public class SecureRandomShareKeyGenerator implements ShareKeyGenerator {
+public class SecureRandomShareKeyGenerator extends SecureRandom
+        implements ShareKeyGenerator {
 
     /**
-     * Instance of SecureRandom for generating sharing keys.
+     * The length of each generated share key, in base64-digits.
      */
-    private final SecureRandom secureRandom = new SecureRandom();
+    private static final int KEY_LENGTH = 44;
+
+    /**
+     * The character representations of each possible base64 digit. This class
+     * uses the URL-safe variant of base64 (also known as "base64url"), which
+     * uses '-' and '_' instead of '+' and '/' for digits 62 and 63
+     * respectively. See RFC 4648, Section 5: "Base 64 Encoding with URL and
+     * Filename Safe Alphabet" (https://tools.ietf.org/html/rfc4648#section-5).
+     */
+    private static final char[] URL_SAFE_BASE64_DIGITS = {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+    };
 
     @Override
     public String getShareKey() {
-        byte[] bytes = new byte[33];
-        secureRandom.nextBytes(bytes);
-        return DatatypeConverter.printBase64Binary(bytes);
+
+        // Produce storage space for required share key length
+        char[] key = new char[KEY_LENGTH];
+
+        // Fill key with random digits
+        for (int i = 0; i < KEY_LENGTH; i++)
+            key[i] = URL_SAFE_BASE64_DIGITS[next(6)];
+
+        return new String(key);
+
     }
 
 }


### PR DESCRIPTION
This change switches from problematic base64 share keys to URL-safe ("base64url", as defined in [RFC 4648, Section 5](https://tools.ietf.org/html/rfc4648#section-5)) share keys. Effective key length remains the same (264-bit).