### PR TITLE
GUACAMOLE-78: Handle anonymous users distinctly.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedAuthenticatedUser.java
@@ -19,7 +19,6 @@
 
 package org.apache.guacamole.auth.jdbc.sharing.user;
 
-import java.util.UUID;
 import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -61,7 +60,8 @@ public class SharedAuthenticatedUser extends RemoteAuthenticatedUser {
     /**
      * Creates a new SharedAuthenticatedUser associating the given user with
      * their corresponding credentials and share key. The identifier (username)
-     * of the user will be randomly generated.
+     * of the user will be the standard identifier for anonymous users as
+     * defined by the Guacamole extension API.
      *
      * @param authenticationProvider
      *     The AuthenticationProvider that has authenticated the given user.
@@ -77,7 +77,7 @@ public class SharedAuthenticatedUser extends RemoteAuthenticatedUser {
             Credentials credentials, String shareKey) {
         super(authenticationProvider, credentials);
         this.shareKey = shareKey;
-        this.identifier = UUID.randomUUID().toString();
+        this.identifier = AuthenticatedUser.ANONYMOUS_IDENTIFIER;
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
@@ -29,6 +29,12 @@ package org.apache.guacamole.net.auth;
 public interface AuthenticatedUser extends Identifiable {
 
     /**
+     * The identifier reserved for representing a user that has authenticated
+     * anonymously.
+     */
+    public static final String ANONYMOUS_IDENTIFIER = "";
+
+    /**
      * Returns the AuthenticationProvider that authenticated this user.
      *
      * @return

--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -257,6 +257,19 @@ angular.module('auth').factory('authenticationService', ['$injector',
     };
 
     /**
+     * Returns whether the current user has authenticated anonymously. An
+     * anonymous user is denoted by the identifier reserved by the Guacamole
+     * extension API for anonymous users (the empty string).
+     *
+     * @returns {Boolean}
+     *     true if the current user has authenticated anonymously, false
+     *     otherwise.
+     */
+    service.isAnonymous = function isAnonymous() {
+        return service.getCurrentUsername() === '';
+    };
+
+    /**
      * Returns the username of the current user. If the current user is not
      * logged in, this value may not be valid.
      *

--- a/guacamole/src/main/webapp/app/auth/types/AuthenticationResult.js
+++ b/guacamole/src/main/webapp/app/auth/types/AuthenticationResult.js
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Service which defines the AuthenticationResult class.
+ */
+angular.module('auth').factory('AuthenticationResult', [function defineAuthenticationResult() {
+            
+    /**
+     * The object returned by REST API calls when representing the successful
+     * result of an authentication attempt.
+     * 
+     * @constructor
+     * @param {AuthenticationResult|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     AuthenticationResult.
+     */
+    var AuthenticationResult = function AuthenticationResult(template) {
+
+        // Use empty object by default
+        template = template || {};
+
+        /**
+         * The unique token generated for the user that authenticated.
+         *
+         * @type String
+         */
+        this.authToken = template.authToken;
+
+        /**
+         * The name which uniquely identifies the user that authenticated.
+         *
+         * @type String
+         */
+        this.username = template.username;
+
+        /**
+         * The unique identifier of the data source which authenticated the
+         * user.
+         *
+         * @type String
+         */
+        this.dataSource = template.dataSource;
+
+        /**
+         * The identifiers of all data sources available to the user that
+         * authenticated.
+         *
+         * @type String[]
+         */
+        this.availableDataSources = template.availableDataSources;
+
+    };
+
+    /**
+     * The username reserved by the Guacamole extension API for users which have
+     * authenticated anonymously.
+     *
+     * @type String
+     */
+    AuthenticationResult.ANONYMOUS_USERNAME = '';
+
+    return AuthenticationResult;
+
+}]);

--- a/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
+++ b/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
@@ -88,7 +88,7 @@ angular.module('index').config(['$routeProvider', '$locationProvider',
 
                 // Otherwise, reject and reroute
                 else {
-                    $location.url(homePage.url);
+                    $location.path(homePage.url);
                     route.reject();
                 }
 

--- a/guacamole/src/main/webapp/app/list/directives/guacUserItem.js
+++ b/guacamole/src/main/webapp/app/list/directives/guacUserItem.js
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A directive which graphically represents an individual user.
+ */
+angular.module('list').directive('guacUserItem', [function guacUserItem() {
+
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The username of the user represented by this guacUserItem.
+             *
+             * @type String
+             */
+            username : '='
+
+        },
+
+        templateUrl: 'app/list/templates/guacUserItem.html',
+        controller: ['$scope', '$injector',
+            function guacUserItemController($scope, $injector) {
+
+            // Required types
+            var AuthenticationResult = $injector.get('AuthenticationResult');
+
+            // Required services
+            var $translate = $injector.get('$translate');
+
+            /**
+             * The string to display when listing the user having the provided
+             * username. Generally, this will be the username itself, but can
+             * also be an arbitrary human-readable representation of the user,
+             * or null if the display name is not yet determined.
+             *
+             * @type String
+             */
+            $scope.displayName = null;
+
+            /**
+             * Returns whether the username provided to this directive denotes
+             * a user that authenticated anonymously.
+             *
+             * @returns {Boolean}
+             *     true if the username provided represents an anonymous user,
+             *     false otherwise.
+             */
+            $scope.isAnonymous = function isAnonymous() {
+                return $scope.username === AuthenticationResult.ANONYMOUS_USERNAME;
+            };
+
+            // Update display name whenever provided username changes
+            $scope.$watch('username', function updateDisplayName(username) {
+
+                // If the user is anonymous, pull the display name for anonymous
+                // users from the translation service
+                if ($scope.isAnonymous()) {
+                    $translate('LIST.TEXT_ANONYMOUS_USER')
+                    .then(function retrieveAnonymousDisplayName(anonymousDisplayName) {
+                        $scope.displayName = anonymousDisplayName;
+                    });
+                }
+
+                // For all other users, use the username verbatim
+                else
+                    $scope.displayName = username;
+
+            });
+
+        }] // end controller
+
+    };
+}]);

--- a/guacamole/src/main/webapp/app/list/styles/user-item.css
+++ b/guacamole/src/main/webapp/app/list/styles/user-item.css
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-/**
- * Module for displaying, sorting, and filtering the contents of a list, split
- * into multiple pages.
- */
-angular.module('list', [
-    'auth'
-]);
+.user-item.anonymous {
+    font-style: italic;
+    opacity: 0.5;
+}

--- a/guacamole/src/main/webapp/app/list/templates/guacUserItem.html
+++ b/guacamole/src/main/webapp/app/list/templates/guacUserItem.html
@@ -1,0 +1,3 @@
+<div class="user-item" ng-class="{'anonymous' : isAnonymous() }">
+    <span class="username">{{displayName}}</span>
+</div>

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -75,7 +75,7 @@
             </thead>
             <tbody>
                 <tr ng-repeat="wrapper in wrapperPage">
-                    <td class="username">{{wrapper.entry.username}}</td>
+                    <td class="username"><guac-user-item username="wrapper.entry.username"></guac-user-item></td>
                     <td class="start">{{wrapper.entry.startDate | date:historyDateFormat}}</td>
                     <td class="duration"
                         translate="{{wrapper.durationText}}"

--- a/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
@@ -68,7 +68,18 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
             .then(function retrievedMainPages(pages) {
                 $scope.pages = pages;
             });
-            
+
+            /**
+             * Returns whether the current user has authenticated anonymously.
+             *
+             * @returns {Boolean}
+             *     true if the current user has authenticated anonymously, false
+             *     otherwise.
+             */
+            $scope.isAnonymous = function isAnonymous() {
+                return authenticationService.isAnonymous();
+            };
+
             /**
              * Logs out the current user, redirecting them to back to the root
              * after logout completes.

--- a/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
+++ b/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
@@ -1,4 +1,4 @@
-<div class="user-menu">
+<div class="user-menu" ng-show="!isAnonymous()">
     <guac-menu menu-title="username">
            
         <!-- Local actions -->

--- a/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
@@ -32,7 +32,7 @@
             </thead>
             <tbody ng-class="{loading: !isLoaded()}">
                 <tr ng-repeat="historyEntryWrapper in historyEntryWrapperPage" class="history">
-                    <td>{{historyEntryWrapper.username}}</td>
+                    <td><guac-user-item username="historyEntryWrapper.username"></guac-user-item></td>
                     <td>{{historyEntryWrapper.startDate | date : dateFormat}}</td>
                     <td translate="{{historyEntryWrapper.readableDurationText}}"
                         translate-values="{VALUE: historyEntryWrapper.readableDuration.value, UNIT: historyEntryWrapper.readableDuration.unit}"></td>

--- a/guacamole/src/main/webapp/app/settings/templates/settingsSessions.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settingsSessions.html
@@ -37,7 +37,7 @@
                 <td class="select-session">
                     <input ng-change="wrapperSelectionChange(wrapper)" type="checkbox" ng-model="wrapper.checked" />
                 </td>
-                <td>{{wrapper.activeConnection.username}}</td>
+                <td><guac-user-item username="wrapper.activeConnection.username"></guac-user-item></td>
                 <td>{{wrapper.startDate}}</td>
                 <td>{{wrapper.activeConnection.remoteHost}}</td>
                 <td>{{wrapper.name}}</td>

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -42,6 +42,7 @@
 
         "INFO_ACTIVE_USER_COUNT" : "Currently in use by {USERS} {USERS, plural, one{user} other{users}}.",
 
+        "TEXT_ANONYMOUS_USER"   : "Anonymous",
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
 
     },
@@ -163,6 +164,12 @@
 
         "SECTION_HEADER_ALL_CONNECTIONS"    : "All Connections",
         "SECTION_HEADER_RECENT_CONNECTIONS" : "Recent Connections"
+
+    },
+
+    "LIST" : {
+
+        "TEXT_ANONYMOUS_USER" : "Anonymous"
 
     },
 


### PR DESCRIPTION
There has historically been no way to properly represent an anonymous user within the Guacamole extension API. All users are required to have unique identifiers, and the user interface renders a user-specific menu with logout button at all times.

This change defines a reserved identifier (`AuthenticatedUser.ANONYMOUS_IDENTIFIER` in Java, `AuthenticationResult.ANONYMOUS_USERNAME` in JavaScript, in both cases simply the empty string) which implicitly declares the user as anonymous, but must not be used for any other purpose. The JDBC authentication has been modified to return this username when a user authenticated via a share key (and thus has no associated user account).

Unlike a traditionally-authenticated user, an anonymous user is not presented the "user menu" which  typically contains the "Home", "Settings", and "Logout" options. When rendered within the admin interface, anonymous users are listed as "Anonymous" with contrasting styling:

![anonymous-username-style](https://cloud.githubusercontent.com/assets/4632905/17641346/4ff54b2e-60d0-11e6-91b3-41227d3f6c7b.png)

Anonymous users' authentication results are also not persisted via a cookie like normal users, thus their session is transient. Closing the tab will effectively log the user out.

Part of this involved actually defining a type within JavaScript for the JSON returned from authentication attempts (now `AuthenticationResult`, in the `auth` module), which up until now has never been documented client-side.