### PR TITLE
GUACAMOLE-79: Adding an option to allow the default LDAP result size limit (1000) to be overridden

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -206,4 +206,23 @@ public class ConfigurationService {
         );
     }
 
+    /**
+     * Returns maximum number of results a LDAP query can return,
+     * as configured with guacamole.properties.
+     * By default, this will be 1000.
+     *
+     * @return
+     *     The maximum number of results a LDAP query can return,
+     *     as configured with guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getMaxResults() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_MAX_SEARCH_RESULTS,
+            1000 
+        );
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -145,4 +145,14 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * The maximum number of results a LDAP query can return.
+     */
+    public static final IntegerGuacamoleProperty LDAP_MAX_SEARCH_RESULTS = new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-max-search-results"; }
+
+    };
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -25,6 +25,7 @@ import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPSearchResults;
+import com.novell.ldap.LDAPSearchConstraints;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -86,6 +87,9 @@ public class UserService {
             String usernameAttribute) throws GuacamoleException {
 
         try {
+            // Set search limits
+            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+            constraints.setMaxResults(confService.getMaxResults());
 
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
@@ -93,7 +97,8 @@ public class UserService {
                 LDAPConnection.SCOPE_SUB,
                 "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*))",
                 null,
-                false
+                false,
+                constraints
             );
 
             // Read all visible users


### PR DESCRIPTION
This is a humble contribution for large Ldap directory (over 1000 accounts).
