### PR TITLE
GUACAMOLE-73: Clear permission cache when saving or updating to force permission reload.

### DIFF
--- a/guacamole/src/main/webapp/app/rest/services/connectionGroupService.js
+++ b/guacamole/src/main/webapp/app/rest/services/connectionGroupService.js
@@ -145,6 +145,10 @@ angular.module('rest').factory('connectionGroupService', ['$injector',
             .success(function connectionGroupCreated(newConnectionGroup){
                 connectionGroup.identifier = newConnectionGroup.identifier;
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly created connection group
+                cacheService.users.removeAll();
             });
         }
 
@@ -160,6 +164,10 @@ angular.module('rest').factory('connectionGroupService', ['$injector',
             // Clear the cache
             .success(function connectionGroupUpdated(){
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly updated connection group
+                cacheService.users.removeAll();
             });
         }
 

--- a/guacamole/src/main/webapp/app/rest/services/connectionService.js
+++ b/guacamole/src/main/webapp/app/rest/services/connectionService.js
@@ -152,6 +152,10 @@ angular.module('rest').factory('connectionService', ['$injector',
             .success(function connectionCreated(newConnection){
                 connection.identifier = newConnection.identifier;
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly created connection
+                cacheService.users.removeAll();
             });
         }
 
@@ -167,6 +171,10 @@ angular.module('rest').factory('connectionService', ['$injector',
             // Clear the cache
             .success(function connectionUpdated(){
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly updated connection
+                cacheService.users.removeAll();
             });
         }
 

--- a/guacamole/src/main/webapp/app/rest/services/sharingProfileService.js
+++ b/guacamole/src/main/webapp/app/rest/services/sharingProfileService.js
@@ -127,6 +127,10 @@ angular.module('rest').factory('sharingProfileService', ['$injector',
             .success(function sharingProfileCreated(newSharingProfile){
                 sharingProfile.identifier = newSharingProfile.identifier;
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly created sharing profile
+                cacheService.users.removeAll();
             });
         }
 
@@ -142,6 +146,10 @@ angular.module('rest').factory('sharingProfileService', ['$injector',
             // Clear the cache
             .success(function sharingProfileUpdated(){
                 cacheService.connections.removeAll();
+
+                // Clear users cache to force reload of permissions for this
+                // newly updated sharing profile
+                cacheService.users.removeAll();
             });
         }
 


### PR DESCRIPTION
The permissions live in the user cache, so clearing the user cache upon save/update of connections or connection groups solves this issue.