### PR TITLE
GUACAMOLE-76: Fix N+1 problem when querying connection group tree.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionModel.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.auth.jdbc.connection;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.guacamole.auth.jdbc.base.GroupedObjectModel;
 
 /**
@@ -52,6 +54,12 @@ public class ConnectionModel extends GroupedObjectModel {
      * or null if the default restrictions should be applied.
      */
     private Integer maxConnectionsPerUser;
+
+    /**
+     * The identifiers of all readable sharing profiles associated with this
+     * connection.
+     */
+    private Set<String> sharingProfileIdentifiers = new HashSet<String>();
 
     /**
      * Creates a new, empty connection.
@@ -150,6 +158,32 @@ public class ConnectionModel extends GroupedObjectModel {
      */
     public void setMaxConnectionsPerUser(Integer maxConnectionsPerUser) {
         this.maxConnectionsPerUser = maxConnectionsPerUser;
+    }
+
+    /**
+     * Returns the identifiers of all readable sharing profiles associated with
+     * this connection. This is set only when the connection is queried, and has
+     * no effect when a connection is inserted, updated, or deleted.
+     *
+     * @return
+     *     The identifiers of all readable sharing profiles associated with
+     *     this connection.
+     */
+    public Set<String> getSharingProfileIdentifiers() {
+        return sharingProfileIdentifiers;
+    }
+
+    /**
+     * Sets the identifiers of all readable sharing profiles associated with
+     * this connection. This should be set only when the connection is queried,
+     * as it has no effect when a connection is inserted, updated, or deleted.
+     *
+     * @param sharingProfileIdentifiers
+     *     The identifiers of all readable sharing profiles associated with
+     *     this connection.
+     */
+    public void setSharingProfileIdentifiers(Set<String> sharingProfileIdentifiers) {
+        this.sharingProfileIdentifiers = sharingProfileIdentifiers;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
@@ -32,7 +32,6 @@ import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObject;
-import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileService;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.NumericField;
@@ -101,12 +100,6 @@ public class ModeledConnection extends ModeledGroupedDirectoryObject<ConnectionM
     private ConnectionService connectionService;
 
     /**
-     * Service for managing sharing profiles.
-     */
-    @Inject
-    private SharingProfileService sharingProfileService;
-
-    /**
      * Service for creating and tracking tunnels.
      */
     @Inject
@@ -167,7 +160,7 @@ public class ModeledConnection extends ModeledGroupedDirectoryObject<ConnectionM
     @Override
     public Set<String> getSharingProfileIdentifiers()
             throws GuacamoleException {
-        return sharingProfileService.getIdentifiersWithin(getCurrentUser(), getIdentifier());
+        return getModel().getSharingProfileIdentifiers();
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.auth.jdbc.connectiongroup;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.guacamole.auth.jdbc.base.GroupedObjectModel;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 
@@ -59,6 +61,18 @@ public class ConnectionGroupModel extends GroupedObjectModel {
      * connection within a balancing group until they log out.
      */
     private boolean sessionAffinityEnabled;
+
+    /**
+     * The identifiers of all readable child connections within this connection
+     * group.
+     */
+    private Set<String> connectionIdentifiers = new HashSet<String>();
+
+    /**
+     * The identifiers of all readable child connection groups within this
+     * connection group.
+     */
+    private Set<String> connectionGroupIdentifiers = new HashSet<String>();
 
     /**
      * Creates a new, empty connection group.
@@ -184,6 +198,62 @@ public class ConnectionGroupModel extends GroupedObjectModel {
      */
     public void setSessionAffinityEnabled(boolean sessionAffinityEnabled) {
         this.sessionAffinityEnabled = sessionAffinityEnabled;
+    }
+
+    /**
+     * Returns the identifiers of all readable child connections within this
+     * connection group. This is set only when the parent connection group is
+     * queried, and has no effect when a connection group is inserted, updated,
+     * or deleted.
+     *
+     * @return
+     *     The identifiers of all readable child connections within this
+     *     connection group.
+     */
+    public Set<String> getConnectionIdentifiers() {
+        return connectionIdentifiers;
+    }
+
+    /**
+     * Sets the identifiers of all readable child connections within this
+     * connection group. This should be set only when the parent connection
+     * group is queried, as it has no effect when a connection group is
+     * inserted, updated, or deleted.
+     *
+     * @param connectionIdentifiers
+     *     The identifiers of all readable child connections within this
+     *     connection group.
+     */
+    public void setConnectionIdentifiers(Set<String> connectionIdentifiers) {
+        this.connectionIdentifiers = connectionIdentifiers;
+    }
+
+    /**
+     * Returns the identifiers of all readable child connection groups within
+     * this connection group. This is set only when the parent connection group
+     * is queried, and has no effect when a connection group is inserted,
+     * updated, or deleted.
+     *
+     * @return
+     *     The identifiers of all readable child connection groups within this
+     *     connection group.
+     */
+    public Set<String> getConnectionGroupIdentifiers() {
+        return connectionGroupIdentifiers;
+    }
+
+    /**
+     * Sets the identifiers of all readable child connection groups within this
+     * connection group. This should be set only when the parent connection
+     * group is queried, as it has no effect when a connection group is
+     * inserted, updated, or deleted.
+     *
+     * @param connectionGroupIdentifiers
+     *     The identifiers of all readable child connection groups within this
+     *     connection group.
+     */
+    public void setConnectionGroupIdentifiers(Set<String> connectionGroupIdentifiers) {
+        this.connectionGroupIdentifiers = connectionGroupIdentifiers;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObject;
-import org.apache.guacamole.auth.jdbc.connection.ConnectionService;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Field;
@@ -100,12 +99,6 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
     private JDBCEnvironment environment;
 
     /**
-     * Service for managing connections.
-     */
-    @Inject
-    private ConnectionService connectionService;
-
-    /**
      * Service for managing connection groups.
      */
     @Inject
@@ -157,13 +150,13 @@ public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<Connec
     @Override
     public Set<String> getConnectionIdentifiers()
             throws GuacamoleException {
-        return connectionService.getIdentifiersWithin(getCurrentUser(), getIdentifier());
+        return getModel().getConnectionIdentifiers();
     }
 
     @Override
     public Set<String> getConnectionGroupIdentifiers()
             throws GuacamoleException {
-        return connectionGroupService.getIdentifiersWithin(getCurrentUser(), getIdentifier());
+        return getModel().getConnectionGroupIdentifiers();
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.java
@@ -19,9 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc.sharingprofile;
 
-import java.util.Set;
 import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObjectMapper;
-import org.apache.guacamole.auth.jdbc.user.UserModel;
 import org.apache.ibatis.annotations.Param;
 
 /**
@@ -31,43 +29,6 @@ import org.apache.ibatis.annotations.Param;
  */
 public interface SharingProfileMapper
         extends ModeledDirectoryObjectMapper<SharingProfileModel> {
-
-    /**
-     * Selects the identifiers of all sharing profiles associated with the given
-     * primary connection, regardless of whether they are readable by any
-     * particular user. This should only be called on behalf of a system
-     * administrator. If identifiers are needed by a non-administrative user who
-     * must have explicit read rights, use selectReadableIdentifiersWithin()
-     * instead.
-     *
-     * @param primaryConnectionIdentifier
-     *     The identifier of the primary connection.
-     *
-     * @return
-     *     A Set containing all identifiers of all objects.
-     */
-    Set<String> selectIdentifiersWithin(
-            @Param("primaryConnectionIdentifier") String primaryConnectionIdentifier);
-    
-    /**
-     * Selects the identifiers of all sharing profiles associated with the given
-     * primary connection that are explicitly readable by the given user. If
-     * identifiers are needed by a system administrator (who, by definition,
-     * does not need explicit read rights), use selectIdentifiersWithin()
-     * instead.
-     *
-     * @param user
-     *    The user whose permissions should determine whether an identifier
-     *    is returned.
-     *
-     * @param primaryConnectionIdentifier
-     *     The identifier of the primary connection.
-     *
-     * @return
-     *     A Set containing all identifiers of all readable objects.
-     */
-    Set<String> selectReadableIdentifiersWithin(@Param("user") UserModel user,
-            @Param("primaryConnectionIdentifier") String primaryConnectionIdentifier);
 
     /**
      * Selects the sharing profile associated with the given primary connection

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileService.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObjectMapper;
 import org.apache.guacamole.GuacamoleClientException;
@@ -242,43 +241,6 @@ public class SharingProfileService
         if (!parameterModels.isEmpty())
             parameterMapper.insert(parameterModels);
         
-    }
-
-    /**
-     * Returns the set of all identifiers for all sharing profiles associated
-     * with the given primary connection. Only sharing profiles that the user
-     * has read access to will be returned.
-     *
-     * Permission to read the primary connection having the given identifier is
-     * NOT checked.
-     *
-     * @param user
-     *     The user retrieving the identifiers.
-     * 
-     * @param identifier
-     *     The identifier of the primary connection.
-     *
-     * @return
-     *     The set of all identifiers for all sharing profiles associated with
-     *     the primary connection having the given identifier that the user has
-     *     read access to.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while reading identifiers.
-     */
-    public Set<String> getIdentifiersWithin(ModeledAuthenticatedUser user,
-            String identifier)
-            throws GuacamoleException {
-
-        // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
-            return sharingProfileMapper.selectIdentifiersWithin(identifier);
-
-        // Otherwise only return explicitly readable identifiers
-        else
-            return sharingProfileMapper.selectReadableIdentifiersWithin(
-                    user.getUser().getModel(), identifier);
-
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
@@ -70,7 +70,7 @@ public class MySQLAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
 
         // Use UTF-8 in database
-        driverProperties.setProperty("characterEncoding","UTF-8");
+        driverProperties.setProperty("characterEncoding", "UTF-8");
 
         // Allow use of multiple statements within a single query
         driverProperties.setProperty("allowMultiQueries", "true");
@@ -86,7 +86,7 @@ public class MySQLAuthenticationProviderModule implements Module {
         // Bind MyBatis properties
         Names.bindProperties(binder, myBatisProperties);
 
-        // Bing JDBC driver properties
+        // Bind JDBC driver properties
         binder.bind(Properties.class)
             .annotatedWith(Names.named("JDBC.driverProperties"))
             .toInstance(driverProperties);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
@@ -72,6 +72,8 @@ public class MySQLAuthenticationProviderModule implements Module {
         // Use UTF-8 in database
         driverProperties.setProperty("characterEncoding","UTF-8");
 
+        // Allow use of multiple statements within a single query
+        driverProperties.setProperty("allowMultiQueries", "true");
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionMapper.xml
@@ -25,12 +25,21 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionResultMap" type="org.apache.guacamole.auth.jdbc.connection.ConnectionModel" >
+
+        <!-- Connection properties -->
         <id     column="connection_id"            property="objectID"              jdbcType="INTEGER"/>
         <result column="connection_name"          property="name"                  jdbcType="VARCHAR"/>
         <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
         <result column="protocol"                 property="protocol"              jdbcType="VARCHAR"/>
         <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
         <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
+
+        <!-- Associated sharing profiles -->
+        <collection property="sharingProfileIdentifiers" resultSet="sharingProfiles" ofType="java.lang.String"
+                    column="connection_id" foreignColumn="primary_connection_id">
+            <result column="sharing_profile_id"/>
+        </collection>
+
     </resultMap>
 
     <!-- Select all connection identifiers -->
@@ -70,7 +79,8 @@
     </select>
 
     <!-- Select multiple connections by identifier -->
-    <select id="select" resultMap="ConnectionResultMap">
+    <select id="select" resultMap="ConnectionResultMap"
+            resultSets="connections,sharingProfiles">
 
         SELECT
             connection_id,
@@ -84,12 +94,21 @@
             <foreach collection="identifiers" item="identifier"
                      open="(" separator="," close=")">
                 #{identifier,jdbcType=VARCHAR}
-            </foreach>
+            </foreach>;
+
+        SELECT primary_connection_id, sharing_profile_id
+        FROM guacamole_sharing_profile
+        WHERE primary_connection_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>;
 
     </select>
 
     <!-- Select multiple connections by identifier only if readable -->
-    <select id="selectReadable" resultMap="ConnectionResultMap">
+    <select id="selectReadable" resultMap="ConnectionResultMap"
+            resultSets="connections,sharingProfiles">
 
         SELECT
             guacamole_connection.connection_id,
@@ -106,7 +125,18 @@
                 #{identifier,jdbcType=VARCHAR}
             </foreach>
             AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
+            AND permission = 'READ';
+
+        SELECT primary_connection_id, guacamole_sharing_profile.sharing_profile_id
+        FROM guacamole_sharing_profile
+        JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
+        WHERE primary_connection_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
 
     </select>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -25,6 +25,8 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.apache.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
+
+        <!-- Connection group properties -->
         <id     column="connection_group_id"      property="objectID"               jdbcType="INTEGER"/>
         <result column="connection_group_name"    property="name"                   jdbcType="VARCHAR"/>
         <result column="parent_id"                property="parentIdentifier"       jdbcType="INTEGER"/>
@@ -33,6 +35,19 @@
         <result column="max_connections"          property="maxConnections"         jdbcType="INTEGER"/>
         <result column="max_connections_per_user" property="maxConnectionsPerUser"  jdbcType="INTEGER"/>
         <result column="enable_session_affinity"  property="sessionAffinityEnabled" jdbcType="BOOLEAN"/>
+
+        <!-- Child connection groups -->
+        <collection property="connectionGroupIdentifiers" resultSet="childConnectionGroups" ofType="java.lang.String"
+                    column="connection_group_id" foreignColumn="parent_id">
+            <result column="connection_group_id"/>
+        </collection>
+
+        <!-- Child connections -->
+        <collection property="connectionIdentifiers" resultSet="childConnections" ofType="java.lang.String"
+                    column="connection_group_id" foreignColumn="parent_id">
+            <result column="connection_id"/>
+        </collection>
+
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -72,7 +87,8 @@
     </select>
 
     <!-- Select multiple connection groups by identifier -->
-    <select id="select" resultMap="ConnectionGroupResultMap">
+    <select id="select" resultMap="ConnectionGroupResultMap"
+            resultSets="connectionGroups,childConnectionGroups,childConnections">
 
         SELECT
             connection_group_id,
@@ -87,12 +103,29 @@
             <foreach collection="identifiers" item="identifier"
                      open="(" separator="," close=")">
                 #{identifier,jdbcType=VARCHAR}
-            </foreach>
+            </foreach>;
+
+        SELECT parent_id, connection_group_id
+        FROM guacamole_connection_group
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>;
+
+        SELECT parent_id, connection_id
+        FROM guacamole_connection
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>;
 
     </select>
 
     <!-- Select multiple connection groups by identifier only if readable -->
-    <select id="selectReadable" resultMap="ConnectionGroupResultMap">
+    <select id="selectReadable" resultMap="ConnectionGroupResultMap"
+            resultSets="connectionGroups,childConnectionGroups,childConnections">
 
         SELECT
             guacamole_connection_group.connection_group_id,
@@ -110,7 +143,29 @@
                 #{identifier,jdbcType=VARCHAR}
             </foreach>
             AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
+            AND permission = 'READ';
+
+        SELECT parent_id, guacamole_connection_group.connection_group_id
+        FROM guacamole_connection_group
+        JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
+
+        SELECT parent_id, guacamole_connection.connection_id
+        FROM guacamole_connection
+        JOIN guacamole_connection_permission ON guacamole_connection_permission.connection_id = guacamole_connection.connection_id
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=VARCHAR}
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
 
     </select>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -45,25 +45,6 @@
             AND permission = 'READ'
     </select>
 
-    <!-- Select all sharing profiles identifiers associated with a particular connection -->
-    <select id="selectIdentifiersWithin" resultType="string">
-        SELECT sharing_profile_id
-        FROM guacamole_sharing_profile
-        WHERE
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=VARCHAR}
-    </select>
-
-    <!-- Select identifiers of all readable sharing profiles associated with a particular connection -->
-    <select id="selectReadableIdentifiersWithin" resultType="string">
-        SELECT guacamole_sharing_profile.sharing_profile_id
-        FROM guacamole_sharing_profile
-        JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
-        WHERE
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=VARCHAR}
-            AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
-    </select>
-
     <!-- Select multiple sharing profiles by identifier -->
     <select id="select" resultMap="SharingProfileResultMap">
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -71,8 +71,7 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
 
         // Use UTF-8 in database
-        driverProperties.setProperty("characterEncoding","UTF-8");
-
+        driverProperties.setProperty("characterEncoding", "UTF-8");
 
     }
 
@@ -85,7 +84,7 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         // Bind MyBatis properties
         Names.bindProperties(binder, myBatisProperties);
 
-        // Bing JDBC driver properties
+        // Bind JDBC driver properties
         binder.bind(Properties.class)
             .annotatedWith(Names.named("JDBC.driverProperties"))
             .toInstance(driverProperties);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionMapper.xml
@@ -25,12 +25,21 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionResultMap" type="org.apache.guacamole.auth.jdbc.connection.ConnectionModel" >
+
+        <!-- Connection properties -->
         <id     column="connection_id"            property="objectID"              jdbcType="INTEGER"/>
         <result column="connection_name"          property="name"                  jdbcType="VARCHAR"/>
         <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
         <result column="protocol"                 property="protocol"              jdbcType="VARCHAR"/>
         <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
         <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
+
+        <!-- Associated sharing profiles -->
+        <collection property="sharingProfileIdentifiers" resultSet="sharingProfiles" ofType="java.lang.String"
+                    column="connection_id" foreignColumn="primary_connection_id">
+            <result column="sharing_profile_id"/>
+        </collection>
+
     </resultMap>
 
     <!-- Select all connection identifiers -->
@@ -70,7 +79,8 @@
     </select>
 
     <!-- Select multiple connections by identifier -->
-    <select id="select" resultMap="ConnectionResultMap">
+    <select id="select" resultMap="ConnectionResultMap"
+            resultSets="connections,sharingProfiles">
 
         SELECT
             connection_id,
@@ -84,12 +94,21 @@
             <foreach collection="identifiers" item="identifier"
                      open="(" separator="," close=")">
                 #{identifier,jdbcType=INTEGER}::integer
-            </foreach>
+            </foreach>;
+
+        SELECT primary_connection_id, sharing_profile_id
+        FROM guacamole_sharing_profile
+        WHERE primary_connection_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>;
 
     </select>
 
     <!-- Select multiple connections by identifier only if readable -->
-    <select id="selectReadable" resultMap="ConnectionResultMap">
+    <select id="selectReadable" resultMap="ConnectionResultMap"
+            resultSets="connections,sharingProfiles">
 
         SELECT
             guacamole_connection.connection_id,
@@ -106,7 +125,18 @@
                 #{identifier,jdbcType=INTEGER}::integer
             </foreach>
             AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
+            AND permission = 'READ';
+
+        SELECT primary_connection_id, guacamole_sharing_profile.sharing_profile_id
+        FROM guacamole_sharing_profile
+        JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
+        WHERE primary_connection_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
 
     </select>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -25,6 +25,8 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.apache.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
+
+        <!-- Connection group properties -->
         <id     column="connection_group_id"      property="objectID"               jdbcType="INTEGER"/>
         <result column="connection_group_name"    property="name"                   jdbcType="VARCHAR"/>
         <result column="parent_id"                property="parentIdentifier"       jdbcType="INTEGER"/>
@@ -33,6 +35,19 @@
         <result column="max_connections"          property="maxConnections"         jdbcType="INTEGER"/>
         <result column="max_connections_per_user" property="maxConnectionsPerUser"  jdbcType="INTEGER"/>
         <result column="enable_session_affinity"  property="sessionAffinityEnabled" jdbcType="BOOLEAN"/>
+
+        <!-- Child connection groups -->
+        <collection property="connectionGroupIdentifiers" resultSet="childConnectionGroups" ofType="java.lang.String"
+                    column="connection_group_id" foreignColumn="parent_id">
+            <result column="connection_group_id"/>
+        </collection>
+
+        <!-- Child connections -->
+        <collection property="connectionIdentifiers" resultSet="childConnections" ofType="java.lang.String"
+                    column="connection_group_id" foreignColumn="parent_id">
+            <result column="connection_id"/>
+        </collection>
+
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -72,7 +87,8 @@
     </select>
 
     <!-- Select multiple connection groups by identifier -->
-    <select id="select" resultMap="ConnectionGroupResultMap">
+    <select id="select" resultMap="ConnectionGroupResultMap"
+            resultSets="connectionGroups,childConnectionGroups,childConnections">
 
         SELECT
             connection_group_id,
@@ -87,12 +103,29 @@
             <foreach collection="identifiers" item="identifier"
                      open="(" separator="," close=")">
                 #{identifier,jdbcType=INTEGER}::integer
-            </foreach>
+            </foreach>;
+
+        SELECT parent_id, connection_group_id
+        FROM guacamole_connection_group
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>;
+
+        SELECT parent_id, connection_id
+        FROM guacamole_connection
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>;
 
     </select>
 
     <!-- Select multiple connection groups by identifier only if readable -->
-    <select id="selectReadable" resultMap="ConnectionGroupResultMap">
+    <select id="selectReadable" resultMap="ConnectionGroupResultMap"
+            resultSets="connectionGroups,childConnectionGroups,childConnections">
 
         SELECT
             guacamole_connection_group.connection_group_id,
@@ -110,7 +143,29 @@
                 #{identifier,jdbcType=INTEGER}::integer
             </foreach>
             AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
+            AND permission = 'READ';
+
+        SELECT parent_id, guacamole_connection_group.connection_group_id
+        FROM guacamole_connection_group
+        JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
+
+        SELECT parent_id, guacamole_connection.connection_id
+        FROM guacamole_connection
+        JOIN guacamole_connection_permission ON guacamole_connection_permission.connection_id = guacamole_connection.connection_id
+        WHERE parent_id IN
+            <foreach collection="identifiers" item="identifier"
+                     open="(" separator="," close=")">
+                #{identifier,jdbcType=INTEGER}::integer
+            </foreach>
+            AND user_id = #{user.objectID,jdbcType=INTEGER}
+            AND permission = 'READ';
 
     </select>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -45,25 +45,6 @@
             AND permission = 'READ'
     </select>
 
-    <!-- Select all sharing profile identifiers associated with a particular connection -->
-    <select id="selectIdentifiersWithin" resultType="string">
-        SELECT sharing_profile_id
-        FROM guacamole_sharing_profile
-        WHERE
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=INTEGER}::integer
-    </select>
-
-    <!-- Select identifiers of all readable sharing profiles associated with a particular connection -->
-    <select id="selectReadableIdentifiersWithin" resultType="string">
-        SELECT guacamole_sharing_profile.sharing_profile_id
-        FROM guacamole_sharing_profile
-        JOIN guacamole_sharing_profile_permission ON guacamole_sharing_profile_permission.sharing_profile_id = guacamole_sharing_profile.sharing_profile_id
-        WHERE
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=INTEGER}::integer
-            AND user_id = #{user.objectID,jdbcType=INTEGER}
-            AND permission = 'READ'
-    </select>
-
     <!-- Select multiple sharing profiles by identifier -->
     <select id="select" resultMap="SharingProfileResultMap">
 


### PR DESCRIPTION
Speed of the connection group tree REST resource fell dramatically with the addition of sharing profiles. This is because the `getSharingProfileIdentifiers()` function of `Connection` issues a new query for every call, and is not affected by retrieval of connections in batches via `getAll()` on the `Directory<Connection>`.

This change addresses this by retrieving child object identifiers when the parents are retrieved. If multiple parents are retrieved, the identifiers of each of their children is retrieved with *one query* (rather than *N queries*). This is accomplished through issuing multiple `SELECT` statements within the same logical query defined in the MyBatis mapping. Beware that while PostgreSQL will handle multiple statements within a single query by default, the MySQL JDBC driver requires a special `allowMultiQueries` property for this.

We should look into making the connection tree retrieval process more efficient, as there are definitely ways it could be sped up (use breadth-first only if attempts to retrieve the entire directory contents at once fail?), but this should fix things with respect to release-blocking regressions. Query performance should be back to where it was.