### PR TITLE
GUACAMOLE-77: Ensure non-existent user accounts are not displayed.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
@@ -39,7 +39,6 @@ import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.simple.SimpleConnectionGroupDirectory;
 import org.apache.guacamole.net.auth.simple.SimpleConnectionRecordSet;
 import org.apache.guacamole.net.auth.simple.SimpleDirectory;
-import org.apache.guacamole.net.auth.simple.SimpleUserDirectory;
 
 /**
  * The user context of a SharedUser, providing access ONLY to the user
@@ -114,9 +113,11 @@ public class SharedUserContext implements UserContext {
         this.connectionGroupDirectory = new SimpleConnectionGroupDirectory(
                 Collections.singletonList(this.rootGroup));
 
-        // The user directory contains only this user
+        // Create internal pseudo-account representing the authenticated user
         this.self = new SharedUser(user, this);
-        this.userDirectory = new SimpleUserDirectory(this.self);
+
+        // Do not provide access to any user accounts via the directory
+        this.userDirectory = new SimpleDirectory<User>();
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -38,8 +38,16 @@
         "NAME" : "MySQL"
     },
 
+    "DATA_SOURCE_MYSQL_SHARED" : {
+        "NAME" : "Shared Connections (MySQL)"
+    },
+
     "DATA_SOURCE_POSTGRESQL" : {
         "NAME" : "PostgreSQL"
+    },
+
+    "DATA_SOURCE_POSTGRESQL_SHARED" : {
+        "NAME" : "Shared Connections (PostgreSQL)"
     },
 
     "HOME" : {

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
@@ -38,6 +38,8 @@ import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.rest.activeconnection.APIActiveConnection;
 import org.apache.guacamole.rest.connection.APIConnection;
 import org.apache.guacamole.rest.connectiongroup.APIConnectionGroup;
+import org.apache.guacamole.rest.directory.DirectoryObjectResource;
+import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.history.HistoryResource;
 import org.apache.guacamole.rest.schema.SchemaResource;
 import org.apache.guacamole.rest.sharingprofile.APISharingProfile;
@@ -56,6 +58,12 @@ public class UserContextResource {
      * The UserContext being exposed through this resource.
      */
     private final UserContext userContext;
+
+    /**
+     * Factory for creating DirectoryObjectResources which expose a given User.
+     */
+    @Inject
+    private DirectoryObjectResourceFactory<User, APIUser> userResourceFactory;
 
     /**
      * Factory for creating DirectoryResources which expose a given
@@ -107,6 +115,26 @@ public class UserContextResource {
     @AssistedInject
     public UserContextResource(@Assisted UserContext userContext) {
         this.userContext = userContext;
+    }
+
+    /**
+     * Returns a new resource which represents the User whose access rights
+     * control the operations of the UserContext exposed by this
+     * UserContextResource.
+     *
+     * @return
+     *     A new resource which represents the User whose access rights
+     *     control the operations of the UserContext exposed by this
+     *     UserContextResource.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the User.
+     */
+    @Path("self")
+    public DirectoryObjectResource<User, APIUser> getSelfResource()
+            throws GuacamoleException {
+        return userResourceFactory.create(userContext,
+                userContext.getUserDirectory(), userContext.self());
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
@@ -29,7 +29,6 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.UserContext;
-import org.apache.guacamole.rest.directory.DirectoryObjectResource;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -43,23 +42,6 @@ import org.apache.guacamole.rest.directory.DirectoryResource;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
-
-    /**
-     * The UserContext associated with the Directory which contains the
-     * User exposed by this resource.
-     */
-    private final UserContext userContext;
-
-    /**
-     * The Directory exposed by this resource.
-     */
-    private final Directory<User> directory;
-
-    /**
-     * A factory which can be used to create instances of resources representing
-     * Users.
-     */
-    private final DirectoryObjectResourceFactory<User, APIUser> resourceFactory;
 
     /**
      * Creates a new UserDirectoryResource which exposes the operations and
@@ -85,9 +67,6 @@ public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
             DirectoryObjectTranslator<User, APIUser> translator,
             DirectoryObjectResourceFactory<User, APIUser> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
-        this.userContext = userContext;
-        this.directory = directory;
-        this.resourceFactory = resourceFactory;
     }
 
     @Override
@@ -98,18 +77,6 @@ public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
             object.setPassword(UUID.randomUUID().toString());
 
         return super.createObject(object);
-
-    }
-
-    @Override
-    public DirectoryObjectResource<User, APIUser>
-        getObjectResource(String identifier) throws GuacamoleException {
-
-        // If username is own username, just use self - might not have query permissions
-        if (userContext.self().getIdentifier().equals(identifier))
-            return resourceFactory.create(userContext, directory, userContext.self());
-
-        return super.getObjectResource(identifier);
 
     }
 


### PR DESCRIPTION
This change establishes the distinction within the REST API between the user object *representing* the current user (`.../self`) and the user object representing an *existing* user (`.../users/{username}`).

This distinction has existed within `UserContext` for some time, but was never exposed within the REST API. It's an important distinction, as just because a backend agrees on a user's identity does not mean the user actually exists within the backend.

By implementing the above change (b23dcf8), and by not listing pseudo-accounts within the user directory of the sharing auth provider (36dc375), the non-relevant pseudo-accounts are no longer displayed as options in the admin interface. In case they ever *do* get displayed somewhere unexpectedly, they will at least be readable, as I've also added actual translation strings (87b517f).