### PR TITLE
GUACAMOLE-81: Verify primary connection permissions when modifying sharing profiles.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ChildObjectModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ChildObjectModel.java
@@ -20,12 +20,13 @@
 package org.apache.guacamole.auth.jdbc.base;
 
 /**
- * Object representation of a Guacamole object, such as a user or connection,
- * as represented in the database.
+ * Object representation of a Guacamole object which can be the child of another
+ * object, such as a connection or sharing profile, as represented in the
+ * database.
  *
  * @author Michael Jumper
  */
-public abstract class GroupedObjectModel extends ObjectModel {
+public abstract class ChildObjectModel extends ObjectModel {
 
     /**
      * The unique identifier which identifies the parent of this object.
@@ -35,7 +36,7 @@ public abstract class GroupedObjectModel extends ObjectModel {
     /**
      * Creates a new, empty object.
      */
-    public GroupedObjectModel() {
+    public ChildObjectModel() {
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObject.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObject.java
@@ -30,7 +30,7 @@ import org.apache.guacamole.auth.jdbc.connectiongroup.RootConnectionGroup;
  * @param <ModelType>
  *     The type of model object that corresponds to this object.
  */
-public abstract class ModeledGroupedDirectoryObject<ModelType extends GroupedObjectModel>
+public abstract class ModeledChildDirectoryObject<ModelType extends ChildObjectModel>
     extends ModeledDirectoryObject<ModelType> {
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionModel.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.connection;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.base.GroupedObjectModel;
+import org.apache.guacamole.auth.jdbc.base.ChildObjectModel;
 
 /**
  * Object representation of a Guacamole connection, as represented in the
@@ -29,7 +29,7 @@ import org.apache.guacamole.auth.jdbc.base.GroupedObjectModel;
  *
  * @author Michael Jumper
  */
-public class ConnectionModel extends GroupedObjectModel {
+public class ConnectionModel extends ChildObjectModel {
 
     /**
      * The human-readable name associated with this connection.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
@@ -34,7 +34,7 @@ import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
-import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObjectService;
+import org.apache.guacamole.auth.jdbc.base.ModeledChildDirectoryObjectService;
 import org.apache.guacamole.auth.jdbc.permission.ConnectionPermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionMapper;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -52,7 +52,7 @@ import org.apache.guacamole.protocol.GuacamoleClientInformation;
  *
  * @author Michael Jumper, James Muehlner
  */
-public class ConnectionService extends ModeledGroupedDirectoryObjectService<ModeledConnection, Connection, ConnectionModel> {
+public class ConnectionService extends ModeledChildDirectoryObjectService<ModeledConnection, Connection, ConnectionModel> {
 
     /**
      * Mapper for accessing connections.
@@ -142,6 +142,15 @@ public class ConnectionService extends ModeledGroupedDirectoryObjectService<Mode
 
         // Return permissions related to connections 
         return user.getUser().getConnectionPermissions();
+
+    }
+
+    @Override
+    protected ObjectPermissionSet getParentPermissionSet(ModeledAuthenticatedUser user)
+            throws GuacamoleException {
+
+        // Connections are contained by connection groups
+        return user.getUser().getConnectionGroupPermissions();
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
-import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObject;
+import org.apache.guacamole.auth.jdbc.base.ModeledChildDirectoryObject;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.NumericField;
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * @author James Muehlner
  * @author Michael Jumper
  */
-public class ModeledConnection extends ModeledGroupedDirectoryObject<ConnectionModel>
+public class ModeledConnection extends ModeledChildDirectoryObject<ConnectionModel>
     implements Connection {
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc.connectiongroup;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.guacamole.auth.jdbc.base.GroupedObjectModel;
+import org.apache.guacamole.auth.jdbc.base.ChildObjectModel;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.guacamole.net.auth.ConnectionGroup;
  *
  * @author Michael Jumper
  */
-public class ConnectionGroupModel extends GroupedObjectModel {
+public class ConnectionGroupModel extends ChildObjectModel {
 
     /**
      * The human-readable name associated with this connection group.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
@@ -29,7 +29,7 @@ import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.GuacamoleUnsupportedException;
-import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObjectService;
+import org.apache.guacamole.auth.jdbc.base.ModeledChildDirectoryObjectService;
 import org.apache.guacamole.auth.jdbc.permission.ConnectionGroupPermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionMapper;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -46,7 +46,7 @@ import org.apache.guacamole.protocol.GuacamoleClientInformation;
  *
  * @author Michael Jumper, James Muehlner
  */
-public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService<ModeledConnectionGroup,
+public class ConnectionGroupService extends ModeledChildDirectoryObjectService<ModeledConnectionGroup,
         ConnectionGroup, ConnectionGroupModel> {
 
     /**
@@ -124,6 +124,15 @@ public class ConnectionGroupService extends ModeledGroupedDirectoryObjectService
             throws GuacamoleException {
 
         // Return permissions related to connection groups 
+        return user.getUser().getConnectionGroupPermissions();
+
+    }
+
+    @Override
+    protected ObjectPermissionSet getParentPermissionSet(ModeledAuthenticatedUser user)
+            throws GuacamoleException {
+
+        // Connection groups are contained by other connection groups
         return user.getUser().getConnectionGroupPermissions();
 
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ModeledConnectionGroup.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
-import org.apache.guacamole.auth.jdbc.base.ModeledGroupedDirectoryObject;
+import org.apache.guacamole.auth.jdbc.base.ModeledChildDirectoryObject;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Field;
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * @author James Muehlner
  * @author Michael Jumper
  */
-public class ModeledConnectionGroup extends ModeledGroupedDirectoryObject<ConnectionGroupModel>
+public class ModeledConnectionGroup extends ModeledChildDirectoryObject<ConnectionGroupModel>
     implements ConnectionGroup {
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/ModeledSharingProfile.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/ModeledSharingProfile.java
@@ -23,7 +23,7 @@ import com.google.inject.Inject;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.guacamole.auth.jdbc.base.ModeledDirectoryObject;
+import org.apache.guacamole.auth.jdbc.base.ModeledChildDirectoryObject;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.net.auth.SharingProfile;
 
@@ -34,7 +34,7 @@ import org.apache.guacamole.net.auth.SharingProfile;
  * @author Michael Jumper
  */
 public class ModeledSharingProfile
-        extends ModeledDirectoryObject<SharingProfileModel>
+        extends ModeledChildDirectoryObject<SharingProfileModel>
         implements SharingProfile {
 
     /**
@@ -72,12 +72,12 @@ public class ModeledSharingProfile
 
     @Override
     public String getPrimaryConnectionIdentifier() {
-        return getModel().getPrimaryConnectionIdentifier();
+        return getModel().getParentIdentifier();
     }
 
     @Override
     public void setPrimaryConnectionIdentifier(String identifier) {
-        getModel().setPrimaryConnectionIdentifier(identifier);
+        getModel().setParentIdentifier(identifier);
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.java
@@ -35,7 +35,7 @@ public interface SharingProfileMapper
      * and having the given name. If no such sharing profile exists, null is
      * returned.
      *
-     * @param primaryConnectionIdentifier
+     * @param parentIdentifier
      *     The identifier of the primary connection to search against.
      *
      * @param name
@@ -46,7 +46,7 @@ public interface SharingProfileMapper
      *     given primary connection, or null if no such sharing profile exists.
      */
     SharingProfileModel selectOneByName(
-            @Param("primaryConnectionIdentifier") String primaryConnectionIdentifier,
+            @Param("parentIdentifier") String parentIdentifier,
             @Param("name") String name);
     
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileModel.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.jdbc.sharingprofile;
 
-import org.apache.guacamole.auth.jdbc.base.ObjectModel;
+import org.apache.guacamole.auth.jdbc.base.ChildObjectModel;
 
 /**
  * Object representation of a Guacamole sharing profile, as represented in the
@@ -27,18 +27,12 @@ import org.apache.guacamole.auth.jdbc.base.ObjectModel;
  *
  * @author Michael Jumper
  */
-public class SharingProfileModel extends ObjectModel {
+public class SharingProfileModel extends ChildObjectModel {
 
     /**
      * The human-readable name associated with this sharing profile.
      */
     private String name;
-
-    /**
-     * The identifier of the primary connection associated with this
-     * sharing profile.
-     */
-    private String primaryConnectionIdentifier;
 
     /**
      * Creates a new, empty sharing profile.
@@ -64,30 +58,6 @@ public class SharingProfileModel extends ObjectModel {
      */
     public void setName(String name) {
         this.name = name;
-    }
-
-    /**
-     * Returns the identifier of the primary connection associated with this
-     * sharing profile.
-     *
-     * @return
-     *     The identifier of the primary connection associated with this
-     *     sharing profile.
-     */
-    public String getPrimaryConnectionIdentifier() {
-        return primaryConnectionIdentifier;
-    }
-
-    /**
-     * Sets the identifier of the primary connection associated with this
-     * sharing profile.
-     *
-     * @param primaryConnectionIdentifier
-     *     The identifier of the primary connection associated with this
-     *     sharing profile.
-     */
-    public void setPrimaryConnectionIdentifier(String primaryConnectionIdentifier) {
-        this.primaryConnectionIdentifier = primaryConnectionIdentifier;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -25,9 +25,9 @@
 
     <!-- Result mapper for sharing profile objects -->
     <resultMap id="SharingProfileResultMap" type="org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileModel">
-        <id     column="sharing_profile_id"    property="objectID"                    jdbcType="INTEGER"/>
-        <result column="sharing_profile_name"  property="name"                        jdbcType="VARCHAR"/>
-        <result column="primary_connection_id" property="primaryConnectionIdentifier" jdbcType="INTEGER"/>
+        <id     column="sharing_profile_id"    property="objectID"         jdbcType="INTEGER"/>
+        <result column="sharing_profile_name"  property="name"             jdbcType="VARCHAR"/>
+        <result column="primary_connection_id" property="parentIdentifier" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all sharing profile identifiers -->
@@ -89,7 +89,7 @@
             primary_connection_id
         FROM guacamole_sharing_profile
         WHERE 
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=VARCHAR}
+            primary_connection_id = #{parentIdentifier,jdbcType=VARCHAR}
             AND sharing_profile_name = #{name,jdbcType=VARCHAR}
 
     </select>
@@ -110,7 +110,7 @@
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
-            #{object.primaryConnectionIdentifier,jdbcType=VARCHAR}
+            #{object.parentIdentifier,jdbcType=VARCHAR}
         )
 
     </insert>
@@ -119,7 +119,7 @@
     <update id="update" parameterType="org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileModel">
         UPDATE guacamole_sharing_profile
         SET sharing_profile_name  = #{object.name,jdbcType=VARCHAR},
-            primary_connection_id = #{object.primaryConnectionIdentifier,jdbcType=VARCHAR}
+            primary_connection_id = #{object.parentIdentifier,jdbcType=VARCHAR}
         WHERE sharing_profile_id = #{object.objectID,jdbcType=INTEGER}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/sharingprofile/SharingProfileMapper.xml
@@ -25,9 +25,9 @@
 
     <!-- Result mapper for sharing profile objects -->
     <resultMap id="SharingProfileResultMap" type="org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileModel">
-        <id     column="sharing_profile_id"    property="objectID"                    jdbcType="INTEGER"/>
-        <result column="sharing_profile_name"  property="name"                        jdbcType="VARCHAR"/>
-        <result column="primary_connection_id" property="primaryConnectionIdentifier" jdbcType="INTEGER"/>
+        <id     column="sharing_profile_id"    property="objectID"         jdbcType="INTEGER"/>
+        <result column="sharing_profile_name"  property="name"             jdbcType="VARCHAR"/>
+        <result column="primary_connection_id" property="parentIdentifier" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all sharing profile identifiers -->
@@ -89,7 +89,7 @@
             primary_connection_id
         FROM guacamole_sharing_profile
         WHERE 
-            primary_connection_id = #{primaryConnectionIdentifier,jdbcType=INTEGER}::integer
+            primary_connection_id = #{parentIdentifier,jdbcType=INTEGER}::integer
             AND sharing_profile_name = #{name,jdbcType=VARCHAR}
 
     </select>
@@ -110,7 +110,7 @@
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
-            #{object.primaryConnectionIdentifier,jdbcType=INTEGER}::integer
+            #{object.parentIdentifier,jdbcType=INTEGER}::integer
         )
 
     </insert>
@@ -119,7 +119,7 @@
     <update id="update" parameterType="org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileModel">
         UPDATE guacamole_sharing_profile
         SET sharing_profile_name  = #{object.name,jdbcType=VARCHAR},
-            primary_connection_id = #{object.primaryConnectionIdentifier,jdbcType=INTEGER}::integer
+            primary_connection_id = #{object.parentIdentifier,jdbcType=INTEGER}::integer
         WHERE sharing_profile_id = #{object.objectID,jdbcType=INTEGER}::integer
     </update>
 


### PR DESCRIPTION
This change generalizes the connection group / connection permission logic such that it can be applied to any parent/child relationship, and reapplies that logic against sharing profiles and their primary (parent) connections.