### PR TITLE
GUACAMOLE-82: Move back to textarea for clipboard for sake of stability.

### DIFF
--- a/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
+++ b/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
@@ -31,6 +31,7 @@
     width: 100%;
     height: 2in;
     white-space: pre;
+    font-size: 1em;
     overflow: auto;
     padding: 0.25em;
 }

--- a/guacamole/src/main/webapp/app/clipboard/templates/guacClipboard.html
+++ b/guacamole/src/main/webapp/app/clipboard/templates/guacClipboard.html
@@ -1,1 +1,1 @@
-<div class="clipboard" contenteditable="true"></div>
+<textarea class="clipboard"></textarea>


### PR DESCRIPTION
This change partially reverts [GUACAMOLE-55](https://issues.apache.org/jira/browse/GUACAMOLE-55), restoring the original `<textarea>` clipboard field while keeping the nice `guacClipboard` directive and data abstraction.

The original change is still worth doing, but not at the expense of 0.9.10-incubating. More time is needed to iron out all the browser quirks related to content-editable divs.