### PR TITLE
GUACAMOLE-95: Minor change to postgresql schema. Fixes saving sessions to history. 

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -359,7 +359,7 @@ CREATE TABLE guacamole_connection_history (
   connection_id        integer      DEFAULT NULL,
   connection_name      varchar(128) NOT NULL,
   sharing_profile_id   integer      DEFAULT NULL,
-  sharing_profile_name varchar(128) NOT NULL,
+  sharing_profile_name varchar(128) DEFAULT NULL,
   start_date           timestamptz  NOT NULL,
   end_date             timestamptz  DEFAULT NULL,
 


### PR DESCRIPTION
The colum sharing_profile_name in guacamole_connection_history was set to NOT NULL. Regular sessions do not have a sharing_profile_name so this caused an exception when guacamole tried to save them. Changed it to DEFAULT NULL (like in the mysql schema) to solve to problem.