### PR TITLE
GUACAMOLE-101: add additional search filter function for extentions/guacamole-auth-ldap module

### DIFF
--- a/extensions/guacamole-auth-ldap/README
+++ b/extensions/guacamole-auth-ldap/README
@@ -91,6 +91,11 @@ guacamole.properties such that the authentication provider is available.
 
     # The base DN within which all role based groups can be found.
     ldap-group-base-dn:      ou=groups,dc=example,dc=net
+    
+    # The additional search filter for the user to be authenticated. 
+    # for example , following filter indicate user have to be memeberof exampleGroup. otherwise, authentication will failed.
+    #the filter is also used to filter out all users visible to guacadmin
+    ldap-additional-search-filter: (memberOf=cn=exampleGroup,ou=groups,dc=example,dc=net) 
 
 ------------------------------------------------------------
  Reporting problems

--- a/extensions/guacamole-auth-ldap/README
+++ b/extensions/guacamole-auth-ldap/README
@@ -92,10 +92,10 @@ guacamole.properties such that the authentication provider is available.
     # The base DN within which all role based groups can be found.
     ldap-group-base-dn:      ou=groups,dc=example,dc=net
     
-    # The additional search filter for the user to be authenticated. 
-    # for example , following filter indicate user have to be memeberof exampleGroup. otherwise, authentication will failed.
-    #the filter is also used to filter out all users visible to guacadmin
-    ldap-additional-search-filter: (memberOf=cn=exampleGroup,ou=groups,dc=example,dc=net) 
+    
+    # The ldap filter which appended to the base DN and user identifier attribute,
+    # produces the full DN of the user being authenticated.
+    ldap-user-filter: (memberOf=cn=exampleGroup,ou=groups,dc=example,dc=net) 
 
 ------------------------------------------------------------
  Reporting problems

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -234,52 +234,51 @@ public class AuthenticationProviderService {
 
         boolean authenticated=true;
         // Check if login in user also meet additional search filter.
-        if(confService.getUserSearchFilter() !=null)
-        {
+        if (confService.getUserSearchFilter() != null) {
+
             authenticated=false;
-    	    for (String usernameAttribute : confService.getUsernameAttributes()) {
+            for (String usernameAttribute : confService.getUsernameAttributes()) {
                 try {
-    			     String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "="+credentials.getUsername()+")"
-    						+confService.getUserSearchFilter().trim()+")";
+                    String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "="+credentials.getUsername()+")"
+                            +confService.getUserSearchFilter().trim()+")";
 
-    				 logger.debug("ldap search filter is :"+ldapSearchFilter);
-    				 // Find all Guacamole users underneath base DN
-    				 LDAPSearchResults results = ldapConnection.search(
-    						confService.getUserBaseDN(),
-    						LDAPConnection.SCOPE_SUB,
-    						ldapSearchFilter,
-    						null,
-    						false
-    						);
+                    logger.debug("ldap search filter is :"+ldapSearchFilter);
+                    // Find all Guacamole users underneath base DN
+                    LDAPSearchResults results = ldapConnection.search(
+                            confService.getUserBaseDN(),
+                            LDAPConnection.SCOPE_SUB,
+                            ldapSearchFilter,
+                            null,
+                            false
+                            );
 
-    				 // Read all visible users
-    				 if (results.hasMore()) {	
-    					 authenticated=true;
-    					 logger.debug("LDAP search find at least one match with filter: "+ldapSearchFilter);
-    					
-    				 }
-    			}
-    			catch (LDAPException e) {
-    				logger.warn("LDAP search failed with user filter: {} ", e.getMessage());
-    				throw new GuacamoleServerException("Error while querying users with additional filter", e);
-    			}
-    		}
-    	}
+                    // Read all visible users
+                    if (results.hasMore()) {	
+                        authenticated=true;
+                        logger.debug("LDAP search find at least one match with filter: "+ldapSearchFilter);
+
+                    }
+                }
+                catch (LDAPException e) {
+                    logger.warn("LDAP search failed with user filter: {} ", e.getMessage());
+                    throw new GuacamoleServerException("Error while querying users with additional filter", e);
+                }
+            }
+        }
 
 
         try {
-             if (authenticated)
-    	     {
-    		    // Return AuthenticatedUser if bind succeeds
-    		     AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
-    		     authenticatedUser.init(credentials);
-    		     return authenticatedUser;
-    	     }
-    	     else
-    	     {
-    		     throw new GuacamoleInvalidCredentialsException("Permission denied. doesn't meet additional filter"+confService.getUserSearchFilter(),
-    				CredentialsInfo.USERNAME_PASSWORD);
-    	     }
+            if (authenticated) {
+                // Return AuthenticatedUser if bind succeeds
+                AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
+                authenticatedUser.init(credentials);
+                return authenticatedUser;
+            }
+            else
+            {
+                throw new GuacamoleInvalidCredentialsException("Permission denied. doesn't meet additional filter"+confService.getUserSearchFilter(),
+                        CredentialsInfo.USERNAME_PASSWORD);
+            }
         }
 
         // Always disconnect

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -239,9 +239,11 @@ public class AuthenticationProviderService {
             authenticated=false;
             for (String usernameAttribute : confService.getUsernameAttributes()) {
                 try {
-                    String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "="+credentials.getUsername()+")"
-                            +confService.getUserSearchFilter().trim()+")";
-
+                    String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "="+credentials.getUsername()+")";
+                    if ( confService.getUserSearchFilter() != null )
+                        ldapSearchFilter+=confService.getUserSearchFilter().trim() ;                    
+                    ldapSearchFilter+= ")";
+                    
                     logger.debug("ldap search filter is :"+ldapSearchFilter);
                     // Find all Guacamole users underneath base DN
                     LDAPSearchResults results = ldapConnection.search(

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -205,5 +205,12 @@ public class ConfigurationService {
             EncryptionMethod.NONE
         );
     }
+    
+    public String getAdditionalSearchFilter() throws GuacamoleException{
+    	 return environment.getProperty(
+    	        LDAPGuacamoleProperties.ADDITIONAL_LDAP_SEARCH_FILTERS,
+    	        ""
+    	 );
+    }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -206,10 +206,21 @@ public class ConfigurationService {
         );
     }
     
-    public String getAdditionalSearchFilter() throws GuacamoleException{
+    /**
+     * Returns the user filter which should be appended to the user identifier attributes
+     * to query and authenticate users using the LDAP directory. If no filter is provided, null is
+     * returned. 
+     * 
+     * @return
+     *     the user filter which should be appended to the user identifier attributes
+     *     to query and authenticate users using the LDAP directory. If no filter is provided, null is
+     *     returned.
+     * @throws GuacamoleException
+     *     if guqacamole.properties cannot be parsed.
+     */
+    public String getUserSearchFilter() throws GuacamoleException{
     	 return environment.getProperty(
-    	        LDAPGuacamoleProperties.ADDITIONAL_LDAP_SEARCH_FILTERS,
-    	        ""
+    	        LDAPGuacamoleProperties.LDAP_USER_FILTER
     	 );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -219,9 +219,9 @@ public class ConfigurationService {
      *     if guqacamole.properties cannot be parsed.
      */
     public String getUserSearchFilter() throws GuacamoleException{
-    	 return environment.getProperty(
-    	        LDAPGuacamoleProperties.LDAP_USER_FILTER
-    	 );
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_USER_FILTER
+        );
     }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -154,7 +154,6 @@ public class LDAPConnectionService {
 
             // Bind as user
             ldapConnection.bind(LDAPConnection.LDAP_V3, userDN, passwordBytes);
-           
 
         }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -154,6 +154,7 @@ public class LDAPConnectionService {
 
             // Bind as user
             ldapConnection.bind(LDAPConnection.LDAP_V3, userDN, passwordBytes);
+           
 
         }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -144,5 +144,8 @@ public class LDAPGuacamoleProperties {
         public String getName() { return "ldap-encryption-method"; }
 
     };
-
+    public static final StringGuacamoleProperty ADDITIONAL_LDAP_SEARCH_FILTERS = new StringGuacamoleProperty(){
+    	  @Override
+          public String getName() { return "ldap-additional-search-filter"; }
+    };
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -144,8 +144,14 @@ public class LDAPGuacamoleProperties {
         public String getName() { return "ldap-encryption-method"; }
 
     };
-    public static final StringGuacamoleProperty ADDITIONAL_LDAP_SEARCH_FILTERS = new StringGuacamoleProperty(){
-    	  @Override
-          public String getName() { return "ldap-additional-search-filter"; }
+    
+    /**
+     * The user filter provided to LDAP server which appended to the base DN and user identifier attribute,
+     * produces the full DN of the user being authenticated. 
+     */
+    public static final StringGuacamoleProperty LDAP_USER_FILTER = new StringGuacamoleProperty(){
+    	  
+    	@Override
+        public String getName() { return "ldap-user-filter"; }
     };
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -150,8 +150,8 @@ public class LDAPGuacamoleProperties {
      * produces the full DN of the user being authenticated. 
      */
     public static final StringGuacamoleProperty LDAP_USER_FILTER = new StringGuacamoleProperty(){
-    	  
-    	@Override
+
+        @Override
         public String getName() { return "ldap-user-filter"; }
     };
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -84,12 +84,13 @@ public class UserService {
      */
     private void putAllUsers(Map<String, User> users, LDAPConnection ldapConnection,
             String usernameAttribute) throws GuacamoleException {
-    
+
         try {
-        	String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)"
-        			+confService.getAdditionalSearchFilter().trim()+")";
         	
-        	logger.debug("list all user using ldap search filter:"+ldapSearchFilter);
+        	String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)"
+        			+confService.getUserSearchFilter().trim()+")";
+        	
+        	logger.debug("list all user using ldap search filter: "+ldapSearchFilter);
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
                 confService.getUserBaseDN(),

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -87,8 +87,10 @@ public class UserService {
 
         try {
 
-            String ldapSearchFilter = "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute)
-                   + "=*)" + confService.getUserSearchFilter().trim() + ")";
+            String ldapSearchFilter = "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute)+ "=*)";
+            if ( confService.getUserSearchFilter() != null )
+                ldapSearchFilter+=confService.getUserSearchFilter().trim() ;            
+            ldapSearchFilter+= ")";
 
             logger.debug("list all user using ldap search filter: " + ldapSearchFilter);
             // Find all Guacamole users underneath base DN

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -86,19 +86,18 @@ public class UserService {
             String usernameAttribute) throws GuacamoleException {
 
         try {
-        	
-        	String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)"
-        			+confService.getUserSearchFilter().trim()+")";
-        	
-        	logger.debug("list all user using ldap search filter: "+ldapSearchFilter);
+
+            String ldapSearchFilter = "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute)
+                   + "=*)" + confService.getUserSearchFilter().trim() + ")";
+
+            logger.debug("list all user using ldap search filter: " + ldapSearchFilter);
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
-                confService.getUserBaseDN(),
+                confService.getUserBaseDN(), 
                 LDAPConnection.SCOPE_SUB,
-                ldapSearchFilter,
-                null,
-                false
-            );
+                ldapSearchFilter, 
+                null, 
+                false);
 
             // Read all visible users
             while (results.hasMore()) {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -84,14 +84,17 @@ public class UserService {
      */
     private void putAllUsers(Map<String, User> users, LDAPConnection ldapConnection,
             String usernameAttribute) throws GuacamoleException {
-
+    
         try {
-
+        	String ldapSearchFilter= "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)"
+        			+confService.getAdditionalSearchFilter().trim()+")";
+        	
+        	logger.debug("list all user using ldap search filter:"+ldapSearchFilter);
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
                 confService.getUserBaseDN(),
                 LDAPConnection.SCOPE_SUB,
-                "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*))",
+                ldapSearchFilter,
                 null,
                 false
             );


### PR DESCRIPTION
update extentions/guacamole-auth-ldap module.
Provide a way to do additional filter of ldap authentication.  the "ldap-additional-search-filter" can be added to guacamole.properties. it is default to empty string.  it's also flexible enough to accept any ldap search filter parameters.
  For example,  to ensure user login is also part of user group "exampleGroup"  
following filter indicate user have to be memeberof exampleGroup:

```
ldap-additional-search-filter: (memberOf=cn=exampleGroup,ou=groups,dc=example,dc=net) 
```
