### PR TITLE
GUACAMOLE-133: Remove unnecessary bundled SLF4J from JDBC auth.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
@@ -105,13 +105,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- SLF4J - logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
-        </dependency>
-
         <!-- MyBatis -->
         <dependency>
             <groupId>org.mybatis</groupId>


### PR DESCRIPTION
SLF4J is provided within the classpath by the Guacamole webapp. There's no need for it to be bundled within extension .jars.