### PR TITLE
GUACAMOLE-133: Exclude StAX dependency, which is part of Java 6.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -480,6 +480,15 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-json</artifactId>
             <version>1.17.1</version>
+
+            <!-- Exclude StAX API, which is part of Java 6 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.stream</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+            </exclusions>
+
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Java 6 ships with a reference implementation of StAX. There's no need for it to be transitively bundled.