### PR TITLE
GUACAMOLE-132: Include ALL .gitignore in source .tar.gz, not just top-level.

### DIFF
--- a/project-assembly.xml
+++ b/project-assembly.xml
@@ -45,7 +45,7 @@
             <directory>${project.basedir}</directory>
             <useDefaultExcludes>false</useDefaultExcludes>
             <includes>
-                <include>.gitignore</include>
+                <include>**/.gitignore</include>
             </includes>
         </fileSet>
 


### PR DESCRIPTION
Some `.gitignore` files are missing from the source archive, thus the RAT portion of the build is still failing for anything but a git checkout. Without these changes, only the top-level `.gitignore` is present.