### PR TITLE
GUACAMOLE-136: Handle expired password reset within getUserContext()

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -25,6 +25,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.sharing.user.SharedAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUserContext;
+import org.apache.guacamole.auth.jdbc.user.UserModel;
 import org.apache.guacamole.auth.jdbc.user.UserService;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -97,6 +98,11 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
                     CredentialsInfo.USERNAME_PASSWORD);
 
         }
+
+        // Update password if password is expired
+        UserModel userModel = user.getModel();
+        if (userModel.isExpired())
+            userService.resetExpiredPassword(user, authenticatedUser.getCredentials());
 
         // Link to user context
         ModeledUserContext context = userContextProvider.get();


### PR DESCRIPTION
The JDBC auth handles resetting of expired passwords within `authenticateUser()`, which doesn't play nicely with secondary authentication factors. The process ends up being:

1. User logs in
2. User is prompted to reset their password
3. User is verified with secondary authentication factors

Which is bad. Presumably the user's identity should be verified *before* allowing them to change their password. By moving the reset process to `getUserContext()`, the ordering of the process is fixed:

1. User logs in
2. User is verified with secondary authentication factors
3. User is prompted to reset their password
