### PR TITLE
GUACAMOLE-154: Bump version numbers to 0.9.11-incubating for modified components.

### DIFF
--- a/extensions/guacamole-auth-duo/pom.xml
+++ b/extensions/guacamole-auth-duo/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-duo</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-auth-duo</name>
     <url>http://guacamole.incubator.apache.org/</url>
 
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.10-incubating",
+    "guacamoleVersion" : "0.9.11-incubating",
 
     "name"      : "Duo TFA Authentication Backend",
     "namespace" : "duo",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.10-incubating</version>
+        <version>0.9.11-incubating</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.10-incubating</version>
+        <version>0.9.11-incubating</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -99,14 +99,14 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-mysql</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
         </dependency>
 
         <!-- PostgreSQL Authentication Extension -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-postgresql</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.10-incubating</version>
+        <version>0.9.11-incubating</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.10-incubating",
+    "guacamoleVersion" : "0.9.11-incubating",
 
     "name"      : "MySQL Authentication",
     "namespace" : "guac-mysql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.10-incubating</version>
+        <version>0.9.11-incubating</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.10-incubating",
+    "guacamoleVersion" : "0.9.11-incubating",
 
     "name"      : "PostgreSQL Authentication",
     "namespace" : "guac-postgresql",

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-jdbc</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-auth-jdbc</name>
     <url>http://guacamole.incubator.apache.org/</url>
 
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>org.apache.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>0.9.10-incubating</version>
+                <version>0.9.11-incubating</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-auth-ldap</name>
     <url>http://guacamole.incubator.apache.org/</url>
 
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.10-incubating",
+    "guacamoleVersion" : "0.9.11-incubating",
 
     "name"      : "LDAP Authentication",
     "namespace" : "guac-ldap",

--- a/extensions/guacamole-auth-noauth/pom.xml
+++ b/extensions/guacamole-auth-noauth/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-noauth</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-auth-noauth</name>
     <url>http://guacamole.incubator.apache.org/</url>
 
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.11-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.10-incubating",
+    "guacamoleVersion" : "0.9.11-incubating",
 
     "name"      : "Disabled Authentication",
     "namespace" : "guac-noauth",

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-ext</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-ext</name>
     <url>http://guacamole.incubator.apache.org/</url>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole</artifactId>
     <packaging>war</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole</name>
     <url>http://guacamole.incubator.apache.org/</url>
 

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -61,7 +61,7 @@ public class ExtensionModule extends ServletModule {
     private static final List<String> ALLOWED_GUACAMOLE_VERSIONS =
         Collections.unmodifiableList(Arrays.asList(
             "*",
-            "0.9.10-incubating"
+            "0.9.11-incubating"
         ));
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-client</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.10-incubating</version>
+    <version>0.9.11-incubating</version>
     <name>guacamole-client</name>
     <url>http://guacamole.incubator.apache.org/</url>
 


### PR DESCRIPTION
`guacamole-common` and `guacamole-common-js` are unmodified.