### PR TITLE
GUACAMOLE-163: Remove DEFAULT CURRENT_TIMESTAMP from password_date.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -85,7 +85,7 @@ CREATE TABLE `guacamole_user` (
   `username`      varchar(128) NOT NULL,
   `password_hash` binary(32)   NOT NULL,
   `password_salt` binary(32),
-  `password_date` datetime     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `password_date` datetime     NOT NULL,
 
   -- Account disabled/expired status
   `disabled`      boolean      NOT NULL DEFAULT 0,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/002-create-admin-user.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/002-create-admin-user.sql
@@ -18,10 +18,11 @@
 --
 
 -- Create default user "guacadmin" with password "guacadmin"
-INSERT INTO guacamole_user (username, password_hash, password_salt)
+INSERT INTO guacamole_user (username, password_hash, password_salt, password_date)
 VALUES ('guacadmin',
     x'CA458A7D494E3BE824F5E1E175A1556C0F8EEF2C2D7DF3633BEC4A29C4411960',  -- 'guacadmin'
-    x'FE24ADC5E11E2B25288D1704ABE67A79E342ECC26064CE69C5B3177795A82264');
+    x'FE24ADC5E11E2B25288D1704ABE67A79E342ECC26064CE69C5B3177795A82264',
+    NOW());
 
 -- Grant this user all system permissions
 INSERT INTO guacamole_system_permission

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.11.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.11.sql
@@ -22,7 +22,12 @@
 --
 
 ALTER TABLE guacamole_user
-    ADD COLUMN password_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+    ADD COLUMN password_date DATETIME;
+
+UPDATE guacamole_user SET password_date = NOW();
+
+ALTER TABLE guacamole_user
+    MODIFY COLUMN password_date DATETIME NOT NULL;
 
 --
 -- User password history

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -126,7 +126,7 @@ CREATE TABLE guacamole_user (
   username      varchar(128) NOT NULL,
   password_hash bytea        NOT NULL,
   password_salt bytea,
-  password_date timestamptz  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  password_date timestamptz  NOT NULL,
 
   -- Account disabled/expired status
   disabled      boolean      NOT NULL DEFAULT FALSE,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/002-create-admin-user.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/002-create-admin-user.sql
@@ -19,10 +19,11 @@
 
 
 -- Create default user "guacadmin" with password "guacadmin"
-INSERT INTO guacamole_user (username, password_hash, password_salt)
+INSERT INTO guacamole_user (username, password_hash, password_salt, password_date)
 VALUES ('guacadmin',
     E'\\xCA458A7D494E3BE824F5E1E175A1556C0F8EEF2C2D7DF3633BEC4A29C4411960',  -- 'guacadmin'
-    E'\\xFE24ADC5E11E2B25288D1704ABE67A79E342ECC26064CE69C5B3177795A82264');
+    E'\\xFE24ADC5E11E2B25288D1704ABE67A79E342ECC26064CE69C5B3177795A82264',
+    CURRENT_TIMESTAMP);
 
 -- Grant this user all system permissions
 INSERT INTO guacamole_system_permission

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.11.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.11.sql
@@ -22,7 +22,12 @@
 --
 
 ALTER TABLE guacamole_user
-    ADD COLUMN password_date timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP;
+    ADD COLUMN password_date timestamptz;
+
+UPDATE guacamole_user SET password_date = CURRENT_TIMESTAMP;
+
+ALTER TABLE guacamole_user
+    ALTER COLUMN password_date SET NOT NULL;
 
 --
 -- User password history


### PR DESCRIPTION
Specifying `DEFAULT CURRENT_TIMESTAMP` for a `DATETIME` column is not supported for MySQL 5.5 and older, breaking compatibility. This change removes `DEFAULT CURRENT_TIMESTAMP` entirely, as it's there purely for convenience. The database auth extension itself always specifies a non-`NULL` value when setting the password.