### PR TITLE
GUACAMOLE-172: Do not send potentially-invalid "sync" as a keep-alive.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -1346,7 +1346,7 @@ Guacamole.Client = function(tunnel) {
 
         // Ping every 5 seconds (ensure connection alive)
         pingInterval = window.setInterval(function() {
-            tunnel.sendMessage("sync", currentTimestamp);
+            tunnel.sendMessage("nop");
         }, 5000);
 
         setState(STATE_WAITING);


### PR DESCRIPTION
This change alters the keep-alive ping of `Guacamole.Client` such that it sends a `nop` instruction rather than a `sync`. If the keep-alive ping occurs prior to receipt of the first frame (no `sync` has been received), then sending the `sync` is a protocol violation. The fact that `currentTimestamp` would be 0 in that case only makes matters worse.