### PR TITLE
GUACAMOLE-47: Get client hostname for use in guac RDP session

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -45,12 +45,12 @@ public class StandardTokens {
     /**
      * The name of the client token added via addStandardTokens().
      */
-    public static final String CLIENT_HOST_TOKEN = "GUAC_REMHOST";
+    public static final String REMHOST_TOKEN = "GUAC_REMHOST";
 
     /**
      * The IP of the client token added via addStandardTokens().
      */
-    public static final String CLIENT_IP_TOKEN = "GUAC_REMIP";
+    public static final String REMIP_TOKEN = "GUAC_REMIP";
 
     /**
      * The name of the date token (server-local time) added via
@@ -129,8 +129,8 @@ public class StandardTokens {
         // Add client hostname and ip tokens
         HttpServletRequest request = credentials.getRequest();
         if (request != null) {
-            filter.setToken(CLIENT_HOST_TOKEN, request.getRemoteHost());
-            filter.setToken(CLIENT_IP_TOKEN, request.getRemoteAddr());
+            filter.setToken(REMHOST_TOKEN, request.getRemoteHost());
+            filter.setToken(REMIP_TOKEN, request.getRemoteAddr());
         }
 
         // Add any tokens which do not require credentials

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -42,6 +42,16 @@ public class StandardTokens {
     public static final String PASSWORD_TOKEN = "GUAC_PASSWORD";
 
     /**
+     * The name of the client token added via addStandardTokens().
+     */
+    public static final String CLIENT_HOST_TOKEN = "GUAC_CLIENT_HOST";
+
+    /**
+     * The IP of the client token added via addStandardTokens().
+     */
+    public static final String CLIENT_IP_TOKEN = "GUAC_CLIENT_IP";
+
+    /**
      * The name of the date token (server-local time) added via
      * addStandardTokens().
      */
@@ -114,6 +124,13 @@ public class StandardTokens {
         String password = credentials.getPassword();
         if (password != null)
             filter.setToken(PASSWORD_TOKEN, password);
+
+        // Add client hostname and ip tokens
+        HttpServletRequest request = credentials.getRequest();
+        if (request != null) {
+            filter.setToken(CLIENT_HOST_TOKEN, request.getRemoteHost());
+            filter.setToken(CLIENT_IP_TOKEN, request.getRemoteAddr());
+        }
 
         // Add any tokens which do not require credentials
         addStandardTokens(filter);

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -45,12 +45,12 @@ public class StandardTokens {
     /**
      * The name of the client token added via addStandardTokens().
      */
-    public static final String REMHOST_TOKEN = "GUAC_REMHOST";
+    public static final String REMHOST_TOKEN = "GUAC_CLIENT_HOSTNAME";
 
     /**
      * The IP of the client token added via addStandardTokens().
      */
-    public static final String REMIP_TOKEN = "GUAC_REMIP";
+    public static final String REMIP_TOKEN = "GUAC_CLIENT_ADDRESS";
 
     /**
      * The name of the date token (server-local time) added via

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.token;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import org.apache.guacamole.net.auth.Credentials;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Utility class which provides access to standardized token names, as well as

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -45,12 +45,12 @@ public class StandardTokens {
     /**
      * The name of the client token added via addStandardTokens().
      */
-    public static final String CLIENT_HOST_TOKEN = "GUAC_CLIENT_HOST";
+    public static final String CLIENT_HOST_TOKEN = "GUAC_REMHOST";
 
     /**
      * The IP of the client token added via addStandardTokens().
      */
-    public static final String CLIENT_IP_TOKEN = "GUAC_CLIENT_IP";
+    public static final String CLIENT_IP_TOKEN = "GUAC_REMIP";
 
     /**
      * The name of the date token (server-local time) added via

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -72,7 +72,7 @@ public class APIRequest extends HttpServletRequestWrapper {
         if (request.getHeader("X-Guacamole-Client-Hostname") != null && !request.getHeader("X-Guacamole-Client-Hostname").isEmpty())
             this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
         else if (request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
-            this.remoteHost = request.getHeader("X-Forwarded-For");
+            this.remoteHost = null;
         else if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
             this.remoteHost = request.getRemoteHost();
         else

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -42,12 +42,12 @@ public class APIRequest extends HttpServletRequestWrapper {
     private final Map<String, String[]> parameters;
 
     /**
-     * The remote hostname that initiated the request.
+     * The hostname of the client that initiated the request.
      */
     private final String remoteHost;
 
     /**
-     * The remote ip address that initiated the request.
+     * The ip address of the client that initiated the request.
      */
     private final String remoteAddr;
 
@@ -68,10 +68,10 @@ public class APIRequest extends HttpServletRequestWrapper {
 
         super(request);
 
-        // Grab the remote host info.
+        // Grab the remote host info
         this.remoteHost = request.getRemoteHost();
 
-	// Grab the remote ip info.
+        // Grab the remote ip info
         this.remoteAddr = request.getRemoteAddr();
 
         // Copy parameters from given MultivaluedMap 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -69,16 +69,10 @@ public class APIRequest extends HttpServletRequestWrapper {
         super(request);
 
         // Grab the remote host info.
-        if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
-            this.remoteHost = request.getRemoteHost();
-        else
-            this.remoteHost = null;
+        this.remoteHost = request.getRemoteHost();
 
 	// Grab the remote ip info.
-        if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty())
-            this.remoteAddr = request.getRemoteAddr();
-        else
-            this.remoteAddr = null;
+        this.remoteAddr = request.getRemoteAddr();
 
         // Copy parameters from given MultivaluedMap 
         this.parameters = new HashMap<String, String[]>(parameters.size());

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -42,6 +42,16 @@ public class APIRequest extends HttpServletRequestWrapper {
     private final Map<String, String[]> parameters;
 
     /**
+     * The remote hostname that initiated the request.
+     */
+    private final String remoteHost;
+
+    /**
+     * The remote ip address that initiated the request.
+     */
+    private final String remoteAddr;
+
+    /**
      * Wraps the given HttpServletRequest, using the given MultivaluedMap to
      * provide all request parameters. All HttpServletRequest functions which
      * do not deal with parameter names and values are delegated to the wrapped
@@ -57,6 +67,29 @@ public class APIRequest extends HttpServletRequestWrapper {
             MultivaluedMap<String, String> parameters) {
 
         super(request);
+
+        // Try a few methods to get client info.
+        String clientHostname = "";
+        String clientAddress = "";
+        if(request.getHeader("X-Guacamole-Client-Hostname") != "") {
+            this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
+        } else if(request.getHeader("X-Forwarded-For") != "") {
+            this.remoteHost = request.getHeader("X-Forwarded-For");
+        } else if(request.getRemoteHost() != "") {
+            this.remoteHost = request.getRemoteHost();
+        } else {
+            this.remoteHost = "";
+        }
+
+        if(request.getHeader("X-Guacamole-Client-IP") != "") {
+            this.remoteAddr = request.getHeader("X-Guacamole-Client-IP");
+        } else if(request.getHeader("X-Forwarded-For") != "") {
+            this.remoteAddr = request.getHeader("X-Forwarded-For");
+        } else if(request.getRemoteAddr() != "") {
+            this.remoteAddr = request.getRemoteAddr();
+        } else {
+            this.remoteAddr = "";
+        }
 
         // Copy parameters from given MultivaluedMap 
         this.parameters = new HashMap<String, String[]>(parameters.size());
@@ -99,6 +132,16 @@ public class APIRequest extends HttpServletRequestWrapper {
         // Otherwise, return first value
         return values[0];
 
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return this.remoteHost;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return this.remoteAddr;
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -69,18 +69,14 @@ public class APIRequest extends HttpServletRequestWrapper {
         super(request);
 
         // Try a few methods to get client info.
-        if (request.getHeader("X-Guacamole-Client-Hostname") != null && !request.getHeader("X-Guacamole-Client-Hostname").isEmpty())
-            this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
-        else if (request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
+        if (request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
             this.remoteHost = null;
         else if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
             this.remoteHost = request.getRemoteHost();
         else
             this.remoteHost = null;
 
-        if (request.getHeader("X-Guacamole-Client-IP") != null && !request.getHeader("X-Guacamole-Client-IP").isEmpty())
-            this.remoteAddr = request.getHeader("X-Guacamole-Client-IP");
-        else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
+        if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
             this.remoteAddr = request.getHeader("X-Forwarded-For");
         else if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty())
             this.remoteAddr = request.getRemoteAddr();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -69,23 +69,21 @@ public class APIRequest extends HttpServletRequestWrapper {
         super(request);
 
         // Try a few methods to get client info.
-        String clientHostname = "";
-        String clientAddress = "";
-        if(request.getHeader("X-Guacamole-Client-Hostname") != "") {
+        if(request.getHeader("X-Guacamole-Client-Hostname") != null && request.getHeader("X-Guacamole-Client-Hostname") != "") {
             this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
-        } else if(request.getHeader("X-Forwarded-For") != "") {
+        } else if(request.getHeader("X-Forwarded-For") != null && request.getHeader("X-Forwarded-For") != "") {
             this.remoteHost = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteHost() != "") {
+        } else if(request.getRemoteHost() != null && request.getRemoteHost() != "") {
             this.remoteHost = request.getRemoteHost();
         } else {
             this.remoteHost = "";
         }
 
-        if(request.getHeader("X-Guacamole-Client-IP") != "") {
+        if(request.getHeader("X-Guacamole-Client-IP") != null && request.getHeader("X-Guacamole-Client-IP") != "") {
             this.remoteAddr = request.getHeader("X-Guacamole-Client-IP");
-        } else if(request.getHeader("X-Forwarded-For") != "") {
+        } else if(request.getHeader("X-Forwarded-For") != null && request.getHeader("X-Forwarded-For") != "") {
             this.remoteAddr = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteAddr() != "") {
+        } else if(request.getRemoteHost() != null && request.getRemoteAddr() != "") {
             this.remoteAddr = request.getRemoteAddr();
         } else {
             this.remoteAddr = "";

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -68,17 +68,14 @@ public class APIRequest extends HttpServletRequestWrapper {
 
         super(request);
 
-        // Try a few methods to get client info.
-        if (request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
-            this.remoteHost = null;
-        else if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
+        // Grab the remote host info.
+        if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
             this.remoteHost = request.getRemoteHost();
         else
             this.remoteHost = null;
 
-        if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
-            this.remoteAddr = request.getHeader("X-Forwarded-For");
-        else if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty())
+	// Grab the remote ip info.
+        if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty())
             this.remoteAddr = request.getRemoteAddr();
         else
             this.remoteAddr = null;

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -69,25 +69,23 @@ public class APIRequest extends HttpServletRequestWrapper {
         super(request);
 
         // Try a few methods to get client info.
-        if(request.getHeader("X-Guacamole-Client-Hostname") != null && !request.getHeader("X-Guacamole-Client-Hostname").isEmpty()) {
+        if (request.getHeader("X-Guacamole-Client-Hostname") != null && !request.getHeader("X-Guacamole-Client-Hostname").isEmpty())
             this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
-        } else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty()) {
+        else if (request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
             this.remoteHost = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteHost() != null && !request.getRemoteHost().isEmpty()) {
+        else if (request.getRemoteHost() != null && !request.getRemoteHost().isEmpty())
             this.remoteHost = request.getRemoteHost();
-        } else {
+        else
             this.remoteHost = null;
-        }
 
-        if(request.getHeader("X-Guacamole-Client-IP") != null && !request.getHeader("X-Guacamole-Client-IP").isEmpty()) {
+        if (request.getHeader("X-Guacamole-Client-IP") != null && !request.getHeader("X-Guacamole-Client-IP").isEmpty())
             this.remoteAddr = request.getHeader("X-Guacamole-Client-IP");
-        } else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty()) {
+        else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty())
             this.remoteAddr = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty()) {
+        else if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty())
             this.remoteAddr = request.getRemoteAddr();
-        } else {
+        else
             this.remoteAddr = null;
-        }
 
         // Copy parameters from given MultivaluedMap 
         this.parameters = new HashMap<String, String[]>(parameters.size());

--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIRequest.java
@@ -69,24 +69,24 @@ public class APIRequest extends HttpServletRequestWrapper {
         super(request);
 
         // Try a few methods to get client info.
-        if(request.getHeader("X-Guacamole-Client-Hostname") != null && request.getHeader("X-Guacamole-Client-Hostname") != "") {
+        if(request.getHeader("X-Guacamole-Client-Hostname") != null && !request.getHeader("X-Guacamole-Client-Hostname").isEmpty()) {
             this.remoteHost = request.getHeader("X-Guacamole-Client-Hostname");
-        } else if(request.getHeader("X-Forwarded-For") != null && request.getHeader("X-Forwarded-For") != "") {
+        } else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty()) {
             this.remoteHost = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteHost() != null && request.getRemoteHost() != "") {
+        } else if(request.getRemoteHost() != null && !request.getRemoteHost().isEmpty()) {
             this.remoteHost = request.getRemoteHost();
         } else {
-            this.remoteHost = "";
+            this.remoteHost = null;
         }
 
-        if(request.getHeader("X-Guacamole-Client-IP") != null && request.getHeader("X-Guacamole-Client-IP") != "") {
+        if(request.getHeader("X-Guacamole-Client-IP") != null && !request.getHeader("X-Guacamole-Client-IP").isEmpty()) {
             this.remoteAddr = request.getHeader("X-Guacamole-Client-IP");
-        } else if(request.getHeader("X-Forwarded-For") != null && request.getHeader("X-Forwarded-For") != "") {
+        } else if(request.getHeader("X-Forwarded-For") != null && !request.getHeader("X-Forwarded-For").isEmpty()) {
             this.remoteAddr = request.getHeader("X-Forwarded-For");
-        } else if(request.getRemoteHost() != null && request.getRemoteAddr() != "") {
+        } else if(request.getRemoteHost() != null && !request.getRemoteAddr().isEmpty()) {
             this.remoteAddr = request.getRemoteAddr();
         } else {
-            this.remoteAddr = "";
+            this.remoteAddr = null;
         }
 
         // Copy parameters from given MultivaluedMap 


### PR DESCRIPTION
These changes allow for the client IP (and/or hostname) to be passed through as parameters to connections, similar to username and password.

I haven't updated any documentation, but it may be necessary given that some configuration changes might be necessary in Tomcat and any proxy servers in front of Tomcat in order to make this work properly.