### PR TITLE
GUACAMOLE-129: Set "Content-Disposition: attachment" for "application/octet-stream".

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/StreamResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/StreamResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.tunnel.StreamInterceptingTunnel;
@@ -103,7 +104,14 @@ public class StreamResource {
 
         };
 
-        return Response.ok(stream, mediaType).build();
+        // Begin successful response
+        ResponseBuilder responseBuilder = Response.ok(stream, mediaType);
+
+        // Set Content-Disposition header for "application/octet-stream"
+        if (mediaType.equals(MediaType.APPLICATION_OCTET_STREAM))
+            responseBuilder.header("Content-Disposition", "attachment");
+
+        return responseBuilder.build();
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
@@ -52,7 +52,7 @@ public class TunnelResource {
      * The media type to send as the content type of stream contents if no
      * other media type is specified.
      */
-    private static final String DEFAULT_MEDIA_TYPE = "application/octet-stream";
+    private static final String DEFAULT_MEDIA_TYPE = MediaType.APPLICATION_OCTET_STREAM;
 
     /**
      * The tunnel that this TunnelResource represents.


### PR DESCRIPTION
Lacking the `Content-Disposition: attachment` header, IE will attempt mimetype detection for the downloaded file (bad), and will possibly rename the file with the wrong extension (even worse).