### PR TITLE
GUACAMOLE-47: Store remote address/hostname within credentials.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -52,6 +52,19 @@ public class Credentials implements Serializable {
     private String password;
 
     /**
+     * The address of the client end of the connection which provided these
+     * credentials, if known.
+     */
+    private String remoteAddress;
+
+    /**
+     * The hostname or, if the hostname cannot be determined, the address of
+     * the client end of the connection which provided these credentials, if
+     * known.
+     */
+    private String remoteHostname;
+
+    /**
      * The HttpServletRequest carrying additional credentials, if any.
      */
     private transient HttpServletRequest request;
@@ -131,6 +144,58 @@ public class Credentials implements Serializable {
      */
     public void setSession(HttpSession session) {
         this.session = session;
+    }
+
+    /**
+     * Returns the address of the client end of the connection which provided
+     * these credentials, if known.
+     *
+     * @return
+     *     The address of the client end of the connection which provided these
+     *     credentials, or null if the address is not known.
+     */
+    public String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    /**
+     * Sets the address of the client end of the connection which provided
+     * these credentials.
+     *
+     * @param remoteAddress
+     *     The address of the client end of the connection which provided these
+     *     credentials, or null if the address is not known.
+     */
+    public void setRemoteAddress(String remoteAddress) {
+        this.remoteAddress = remoteAddress;
+    }
+
+    /**
+     * Returns the hostname of the client end of the connection which provided
+     * these credentials, if known. If the hostname of the client cannot be
+     * determined, but the address is known, the address may be returned
+     * instead.
+     *
+     * @return
+     *     The hostname or address of the client end of the connection which
+     *     provided these credentials, or null if the hostname is not known.
+     */
+    public String getRemoteHostname() {
+        return remoteHostname;
+    }
+
+    /**
+     * Sets the hostname of the client end of the connection which provided
+     * these credentials, if known. If the hostname of the client cannot be
+     * determined, but the address is known, the address may be specified
+     * instead.
+     *
+     * @param remoteHostname
+     *     The hostname or address of the client end of the connection which
+     *     provided these credentials, or null if the hostname is not known.
+     */
+    public void setRemoteHostname(String remoteHostname) {
+        this.remoteHostname = remoteHostname;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -21,8 +21,8 @@ package org.apache.guacamole.token;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import org.apache.guacamole.net.auth.Credentials;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.guacamole.net.auth.Credentials;
 
 /**
  * Utility class which provides access to standardized token names, as well as
@@ -43,14 +43,14 @@ public class StandardTokens {
     public static final String PASSWORD_TOKEN = "GUAC_PASSWORD";
 
     /**
-     * The name of the client token added via addStandardTokens().
+     * The name of the client hostname token added via addStandardTokens().
      */
-    public static final String REMHOST_TOKEN = "GUAC_CLIENT_HOSTNAME";
+    public static final String CLIENT_HOSTNAME_TOKEN = "GUAC_CLIENT_HOSTNAME";
 
     /**
-     * The IP of the client token added via addStandardTokens().
+     * The name of the client address token added via addStandardTokens().
      */
-    public static final String REMIP_TOKEN = "GUAC_CLIENT_ADDRESS";
+    public static final String CLIENT_ADDRESS_TOKEN = "GUAC_CLIENT_ADDRESS";
 
     /**
      * The name of the date token (server-local time) added via
@@ -129,8 +129,8 @@ public class StandardTokens {
         // Add client hostname and ip tokens
         HttpServletRequest request = credentials.getRequest();
         if (request != null) {
-            filter.setToken(REMHOST_TOKEN, request.getRemoteHost());
-            filter.setToken(REMIP_TOKEN, request.getRemoteAddr());
+            filter.setToken(CLIENT_HOSTNAME_TOKEN, request.getRemoteHost());
+            filter.setToken(CLIENT_ADDRESS_TOKEN, request.getRemoteAddr());
         }
 
         // Add any tokens which do not require credentials

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -21,7 +21,6 @@ package org.apache.guacamole.token;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import javax.servlet.http.HttpServletRequest;
 import org.apache.guacamole.net.auth.Credentials;
 
 /**
@@ -126,12 +125,15 @@ public class StandardTokens {
         if (password != null)
             filter.setToken(PASSWORD_TOKEN, password);
 
-        // Add client hostname and ip tokens
-        HttpServletRequest request = credentials.getRequest();
-        if (request != null) {
-            filter.setToken(CLIENT_HOSTNAME_TOKEN, request.getRemoteHost());
-            filter.setToken(CLIENT_ADDRESS_TOKEN, request.getRemoteAddr());
-        }
+        // Add client hostname token
+        String hostname = credentials.getRemoteHostname();
+        if (hostname != null)
+            filter.setToken(CLIENT_HOSTNAME_TOKEN, hostname);
+
+        // Add client address token
+        String address = credentials.getRemoteAddress();
+        if (address != null)
+            filter.setToken(CLIENT_ADDRESS_TOKEN, address);
 
         // Add any tokens which do not require credentials
         addStandardTokens(filter);

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
@@ -125,6 +125,8 @@ public class TokenRESTService {
         credentials.setPassword(password);
         credentials.setRequest(request);
         credentials.setSession(request.getSession(true));
+        credentials.setRemoteAddress(request.getRemoteAddr());
+        credentials.setRemoteHostname(request.getRemoteHost());
 
         return credentials;
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -130,6 +130,8 @@ public class UserResource
         credentials.setPassword(userPasswordUpdate.getOldPassword());
         credentials.setRequest(request);
         credentials.setSession(request.getSession(true));
+        credentials.setRemoteAddress(request.getRemoteAddr());
+        credentials.setRemoteHostname(request.getRemoteHost());
 
         // Verify that the old password was correct
         try {


### PR DESCRIPTION
While documenting the changes made by @necouchman via #109 for [GUACAMOLE-47](https://issues.apache.org/jira/browse/GUACAMOLE-47), I noticed that we are pulling the hostname and address directly from the `HttpServletRequest` each time token substitution takes place. This is bad because servlet containers will often reuse the `HttpServletRequest` object. When pulled from a `Credentials` object, its contents cannot be relied upon outside the scope of the authentication request which produced those `Credentials`.

If these values are to be accessible when users connect via Guacamole, they will need to be stored within `Credentials` just like the username and password.