### PR TITLE
GUACAMOLE-230: Provide oncursor event handler with canvas having exact dimensions

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Display.js
+++ b/guacamole-common-js/src/main/webapp/modules/Display.js
@@ -423,7 +423,7 @@ Guacamole.Display = function() {
 
             // Fire cursor change event
             if (guac_display.oncursor)
-                guac_display.oncursor(cursor.getCanvas(), hotspotX, hotspotY);
+                guac_display.oncursor(cursor.toCanvas(), hotspotX, hotspotY);
 
         });
     };

--- a/guacamole-common-js/src/main/webapp/modules/Layer.js
+++ b/guacamole-common-js/src/main/webapp/modules/Layer.js
@@ -267,11 +267,39 @@ Guacamole.Layer = function(width, height) {
     this.height = height;
 
     /**
-     * Returns the canvas element backing this Layer.
-     * @returns {Element} The canvas element backing this Layer.
+     * Returns the canvas element backing this Layer. Note that the dimensions
+     * of the canvas may not exactly match those of the Layer, as resizing a
+     * canvas while maintaining its state is an expensive operation.
+     *
+     * @returns {HTMLCanvasElement}
+     *     The canvas element backing this Layer.
      */
-    this.getCanvas = function() {
+    this.getCanvas = function getCanvas() {
         return canvas;
+    };
+
+    /**
+     * Returns a new canvas element containing the same image as this Layer.
+     * Unlike getCanvas(), the canvas element returned is guaranteed to have
+     * the exact same dimensions as the Layer.
+     *
+     * @returns {HTMLCanvasElement}
+     *     A new canvas element containing a copy of the image content this
+     *     Layer.
+     */
+    this.toCanvas = function toCanvas() {
+
+        // Create new canvas having same dimensions
+        var canvas = document.createElement('canvas');
+        canvas.width = layer.width;
+        canvas.height = layer.height;
+
+        // Copy image contents to new canvas
+        var context = canvas.getContext('2d');
+        context.drawImage(layer.getCanvas(), 0, 0);
+
+        return canvas;
+
     };
 
     /**


### PR DESCRIPTION
Guacamole implements its layers using a `canvas` wrapped in a `div`, with that outer `div` providing the clipping area. There is thus no internal requirement that the `canvas` itself be the same dimensions as the layer it belongs to, and recent changes ([GUACAMOLE-187](https://issues.apache.org/jira/browse/GUACAMOLE-187) via #113) leveraged this to reduce the number of expensive resize operations attempted when a layer is being continuously resized.

Unfortunately, as described in [GUACAMOLE-230](https://issues.apache.org/jira/browse/GUACAMOLE-230):

> The mouse cursor renders extremely small when set via CSS, at least on Chrome. This seems to be due to layer dimensions now rounding up to the nearest multiple of 64. On high-resolution devices, Chrome assumes that 64x64 cursor image must also be high-resolution, and uses a pixel size inappropriate for the connection. This does not occur for smaller cursor images.

This change adds a new `toCanvas()` function to `Guacamole.Layer` which produces an entirely new canvas representing the contents of the layer. Unlike `getCanvas()`, which returns the internal `canvas` backing the layer itself, `toCanvas()` is guaranteed to return an entirely independent `canvas` which has the same dimensions as the layer. By using `toCanvas()` rather than `getCanvas()` when invoking the `oncursor` handler, cursors now work as they did previously.