### PR TITLE
GUACAMOLE-243: Handle LDAP Referrals

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -223,4 +223,87 @@ public class ConfigurationService {
         );
     }
 
+    /**
+     * Returns the boolean value for whether the connection should
+     * follow referrals or not.  By default, it will not.
+     *
+     * @return
+     *     The boolean value of whether to follow referrals
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public boolean getFollowReferrals() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_FOLLOW_REFERRALS,
+            false
+        );
+    }
+
+    /**
+     * Returns the maximum number of referral hops to follow.
+     *
+     * @return
+     *     The maximum number of referral hops to follow
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getMaxReferralHops() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_MAX_REFERRAL_HOPS,
+            5
+        );
+    }
+
+    /**
+     * Returns the authentication method to use during referral following.
+     *
+     * @return
+     *     The authentication method to use during referral following
+     *     as configured in guacamole.properties or as derived from
+     *     other configuration options.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getReferralAuthentication() throws GuacamoleException {
+        String confMethod = environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_REFERRAL_AUTHENTICATION
+        );
+
+        if (confMethod == null)
+
+            if (getSearchBindDN() != null && getSearchBindPassword() != null)
+                return "bind";
+
+            else
+                return "anonymous";
+
+        else if (confMethod.equals("bind") && (getSearchBindDN() == null || getSearchBindPassword() == null))
+            throw new GuacamoleException("Referral is set to bind with credentials, but credentials are not configured.");
+
+        return confMethod;
+
+    }
+
+    /**
+     * Returns the maximum number of seconds to wait for LDAP operations
+     *
+     * @return
+     *     The maximum number of seconds to wait for LDAP operations
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getOperationTimeout() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_OPERATION_TIMEOUT,
+            30
+        );
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -118,13 +118,16 @@ public class LDAPConnectionService {
         if (ldapConstraints == null)
           ldapConstraints = new LDAPConstraints();
 
-        // Set whether or not we follow referrals, and max hops
+        // Set whether or not we follow referrals
         ldapConstraints.setReferralFollowing(confService.getFollowReferrals());
-        String refAuthMethod = confService.getReferralAuthentication();
 
+        // If the referral auth method is set to bind, we set it using the existing
+        // username and password.
+        String refAuthMethod = confService.getReferralAuthentication();
         if (refAuthMethod != null && refAuthMethod.equals("bind"))
             ldapConstraints.setReferralHandler(new ReferralAuthHandler(userDN, password));
 
+        // Set the maximum number of referrals we follow
         ldapConstraints.setHopLimit(confService.getMaxReferralHops());
 
         // Set timelimit to wait for LDAP operations, converting to ms

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.auth.ldap;
 
+import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 
@@ -150,6 +151,46 @@ public class LDAPGuacamoleProperties {
 
         @Override
         public String getName() { return "ldap-max-search-results"; }
+
+    };
+
+    /**
+     * Whether or not we should follow referrals
+     */
+    public static final BooleanGuacamoleProperty LDAP_FOLLOW_REFERRALS = new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-follow-referrals"; }
+
+    };
+
+    /**
+     * Maximum number of referral hops to follow
+     */
+    public static final IntegerGuacamoleProperty LDAP_MAX_REFERRAL_HOPS = new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-max-referral-hops"; }
+
+    };
+
+    /**
+     * Authentication method to use to follow referrals
+     */
+    public static final StringGuacamoleProperty LDAP_REFERRAL_AUTHENTICATION = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-referral-authentication"; }
+
+    };
+
+    /**
+     * Number of seconds to wait for LDAP operations to complete
+     */
+    public static final IntegerGuacamoleProperty LDAP_OPERATION_TIMEOUT = new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-operation-timeout"; }
 
     };
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap;
+
+import com.google.inject.Inject;
+import com.novell.ldap.LDAPAuthHandler;
+import com.novell.ldap.LDAPAuthProvider;
+import com.novell.ldap.LDAPConnection;
+import java.io.UnsupportedEncodingException;
+import org.apache.guacamole.GuacamoleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReferralAuthHandler implements LDAPAuthHandler {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ReferralAuthHandler.class);
+
+    /**
+     * The LDAPAuthProvider object that will be set and returned to the referral handler.
+     */
+    private final LDAPAuthProvider ldapAuth;
+
+    /**
+     * Service for retrieving LDAP server configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
+
+
+    public ReferralAuthHandler() throws GuacamoleException {
+        String binddn = confService.getSearchBindDN();
+        String password = confService.getSearchBindPassword();
+        byte[] passwordBytes;
+        try {
+
+            // Convert password into corresponding byte array
+            if (password != null)
+                passwordBytes = password.getBytes("UTF-8");
+            else
+                passwordBytes = null;
+
+        }
+        catch (UnsupportedEncodingException e) {
+            logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
+            logger.debug("Support for UTF-8 (as required by Java spec) not found.", e);
+            throw new GuacamoleException("Could not set password due to missing support for UTF-8 encoding.");
+        }
+
+        ldapAuth = new LDAPAuthProvider(binddn, passwordBytes);
+
+    }
+
+    public ReferralAuthHandler(String dn, String password) throws GuacamoleException {
+        byte[] passwordBytes;
+        try {
+
+            // Convert password into corresponding byte array
+            if (password != null)
+                passwordBytes = password.getBytes("UTF-8");
+            else
+                passwordBytes = null;
+
+        }   
+        catch (UnsupportedEncodingException e) {
+            logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
+            logger.debug("Support for UTF-8 (as required by Java spec) not found.", e); 
+            throw new GuacamoleException("Could not set password due to missing UTF-8 support.");
+        }
+        ldapAuth = new LDAPAuthProvider(dn, passwordBytes);
+    }
+
+    @Override
+    public LDAPAuthProvider getAuthProvider(String host, int port) {
+        return ldapAuth;
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -24,6 +24,7 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPReferralException;
 import com.novell.ldap.LDAPSearchResults;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -128,62 +129,80 @@ public class ConnectionService {
             Map<String, Connection> connections = new HashMap<String, Connection>();
             while (results.hasMore()) {
 
-                LDAPEntry entry = results.next();
+                try {
 
-                // Get common name (CN)
-                LDAPAttribute cn = entry.getAttribute("cn");
-                if (cn == null) {
-                    logger.warn("guacConfigGroup is missing a cn.");
-                    continue;
-                }
+                    LDAPEntry entry = results.next();
 
-                // Get associated protocol
-                LDAPAttribute protocol = entry.getAttribute("guacConfigProtocol");
-                if (protocol == null) {
-                    logger.warn("guacConfigGroup \"{}\" is missing the "
-                              + "required \"guacConfigProtocol\" attribute.",
-                            cn.getStringValue());
-                    continue;
-                }
+                    // Get common name (CN)
+                    LDAPAttribute cn = entry.getAttribute("cn");
+                    if (cn == null) {
+                        logger.warn("guacConfigGroup is missing a cn.");
+                        continue;
+                    }
 
-                // Set protocol
-                GuacamoleConfiguration config = new GuacamoleConfiguration();
-                config.setProtocol(protocol.getStringValue());
+                    // Get associated protocol
+                    LDAPAttribute protocol = entry.getAttribute("guacConfigProtocol");
+                    if (protocol == null) {
+                        logger.warn("guacConfigGroup \"{}\" is missing the "
+                                  + "required \"guacConfigProtocol\" attribute.",
+                                cn.getStringValue());
+                        continue;
+                    }
 
-                // Get parameters, if any
-                LDAPAttribute parameterAttribute = entry.getAttribute("guacConfigParameter");
-                if (parameterAttribute != null) {
+                    // Set protocol
+                    GuacamoleConfiguration config = new GuacamoleConfiguration();
+                    config.setProtocol(protocol.getStringValue());
 
-                    // For each parameter
-                    Enumeration<?> parameters = parameterAttribute.getStringValues();
-                    while (parameters.hasMoreElements()) {
+                    // Get parameters, if any
+                    LDAPAttribute parameterAttribute = entry.getAttribute("guacConfigParameter");
+                    if (parameterAttribute != null) {
 
-                        String parameter = (String) parameters.nextElement();
+                        // For each parameter
+                        Enumeration<?> parameters = parameterAttribute.getStringValues();
+                        while (parameters.hasMoreElements()) {
 
-                        // Parse parameter
-                        int equals = parameter.indexOf('=');
-                        if (equals != -1) {
+                            String parameter = (String) parameters.nextElement();
 
-                            // Parse name
-                            String name = parameter.substring(0, equals);
-                            String value = parameter.substring(equals+1);
+                            // Parse parameter
+                            int equals = parameter.indexOf('=');
+                            if (equals != -1) {
 
-                            config.setParameter(name, value);
+                                // Parse name
+                                String name = parameter.substring(0, equals);
+                                String value = parameter.substring(equals+1);
+
+                                config.setParameter(name, value);
+
+                            }
 
                         }
 
                     }
 
+                    // Filter the configuration, substituting all defined tokens
+                    tokenFilter.filterValues(config.getParameters());
+
+                    // Store connection using cn for both identifier and name
+                    String name = cn.getStringValue();
+                    Connection connection = new SimpleConnection(name, name, config);
+                    connection.setParentIdentifier(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP);
+                    connections.put(name, connection);
+
                 }
 
-                // Filter the configuration, substituting all defined tokens
-                tokenFilter.filterValues(config.getParameters());
-
-                // Store connection using cn for both identifier and name
-                String name = cn.getStringValue();
-                Connection connection = new SimpleConnection(name, name, config);
-                connection.setParentIdentifier(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP);
-                connections.put(name, connection);
+                // Deal with issues following LDAP referrals
+                catch (LDAPReferralException e) {
+                    if (confService.getFollowReferrals()) {
+                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.debug("Error encountered trying to follow referral.", e);
+                        throw new GuacamoleServerException("Could not follow LDAP referral.", e);
+                    }
+                    else {
+                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.debug("Got a referral, but configured to not follow them.", e);
+                        continue;
+                    }
+                }
 
             }
 
@@ -249,8 +268,23 @@ public class ConnectionService {
             // The guacConfig group uses the seeAlso attribute to refer
             // to these other groups
             while (userRoleGroupResults.hasMore()) {
-                LDAPEntry entry = userRoleGroupResults.next();
-                connectionSearchFilter.append("(seeAlso=").append(escapingService.escapeLDAPSearchFilter(entry.getDN())).append(")");
+                try {
+                    LDAPEntry entry = userRoleGroupResults.next();
+                    connectionSearchFilter.append("(seeAlso=").append(escapingService.escapeLDAPSearchFilter(entry.getDN())).append(")");
+                }
+
+                catch (LDAPReferralException e) {
+                    if (confService.getFollowReferrals()) {
+                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.debug("Error encountered trying to follow referral.", e);
+                        throw new GuacamoleServerException("Could not follow LDAP referral.", e);
+                    }
+                    else {
+                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.debug("Got a referral, but configured to not follow them.", e);
+                        continue;
+                    }
+                }
             }
         }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -24,6 +24,7 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPReferralException;
 import com.novell.ldap.LDAPSearchResults;
 import com.novell.ldap.LDAPSearchConstraints;
 import java.util.ArrayList;
@@ -102,19 +103,35 @@ public class UserService {
             // Read all visible users
             while (results.hasMore()) {
 
-                LDAPEntry entry = results.next();
+                try {
 
-                // Get username from record
-                LDAPAttribute username = entry.getAttribute(usernameAttribute);
-                if (username == null) {
-                    logger.warn("Queried user is missing the username attribute \"{}\".", usernameAttribute);
-                    continue;
+                    LDAPEntry entry = results.next();
+
+                    // Get username from record
+                    LDAPAttribute username = entry.getAttribute(usernameAttribute);
+                    if (username == null) {
+                        logger.warn("Queried user is missing the username attribute \"{}\".", usernameAttribute);
+                        continue;
+                    }
+
+                    // Store user using their username as the identifier
+                    String identifier = username.getStringValue();
+                    if (users.put(identifier, new SimpleUser(identifier)) != null)
+                        logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
+
                 }
-
-                // Store user using their username as the identifier
-                String identifier = username.getStringValue();
-                if (users.put(identifier, new SimpleUser(identifier)) != null)
-                    logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
+                catch (LDAPReferralException e) {
+                    if (confService.getFollowReferrals()) {
+                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.debug("Error encountered trying to follow referral.", e);
+                        throw new GuacamoleException("Could not follow LDAP referral.");
+                    }
+                    else {
+                        logger.warn("Encountered a referral, but not following it.", e.getMessage());
+                        logger.debug("Got a referral, but not configured to follow it.", e);
+                        continue;
+                    }
+                }
 
             }
 


### PR DESCRIPTION
These changes fix the handling of LDAP referrals sent by the server.  Prior to this, LDAP referrals would cause general LDAPExceptions which would prevent LDAP authentication (and other search operations) from succeeding.  This is actually a follow-up to PR-129, adding on Adam's logic to ignore the referrals in certain scenarios.