### PR TITLE
GUACAMOLE-244: Support configuration of alias dereferencing

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -241,17 +241,23 @@ public class ConfigurationService {
             "never"
         );
 
-        if (derefAliases == "always")
+        if (derefAliases.equals("always"))
             return 3;
 
-        else if (derefAliases == "finding")
+        else if (derefAliases.equals("finding"))
             return 2;
 
-        else if (derefAliases == "searching")
+        else if (derefAliases.equals("searching"))
             return 1;
 
-        else
+        else if (derefAliases.equals("never"))
             return 0;
+        
+        else {
+            logger.error("Invalid value given for ldap-dereference-aliases.");
+            logger.debug("Received {} but expected one of the following: always, finding, searching, never.", derefAliases);
+            throw new GuacamoleException("Invalid valid for ldap-dereference-aliases.");
+        }
 
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -20,15 +20,23 @@
 package org.apache.guacamole.auth.ldap;
 
 import com.google.inject.Inject;
+import com.novell.ldap.LDAPSearchConstraints;
 import java.util.Collections;
 import java.util.List;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service for retrieving configuration information regarding the LDAP server.
  */
 public class ConfigurationService {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ConfigurationService.class);
 
     /**
      * The Guacamole server environment.
@@ -261,6 +269,32 @@ public class ConfigurationService {
             logger.debug("Received {} but expected one of the following: always, finding, searching, never.", derefAliases);
             throw new GuacamoleException("Invalid valid for ldap-dereference-aliases.");
         }
+
+    }
+
+    /**
+     * Returns a set of LDAPSearchConstraints to apply globally
+     * to all LDAP searches rather than having various instances
+     * dispersed throughout the code.  Currently contains the
+     * maximum number of LDAP results to return in a search, as
+     * well as whether or not aliases should be dereferenced
+     * during LDAP operations.
+     *
+     * @return
+     *     A LDAPSearchConstraints object containing constraints
+     *     to be applied to all LDAP search operations.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public LDAPSearchConstraints getLDAPSearchConstraints() throws GuacamoleException {
+
+        LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+
+        constraints.setMaxResults(getMaxResults());
+        constraints.setDereference(getDereferenceAliases());
+
+        return constraints;
 
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -223,4 +223,36 @@ public class ConfigurationService {
         );
     }
 
+    /**
+     * Returns whether or not LDAP aliases will be dereferenced,
+     * as configured with guacamole.properties.
+     * By default they will never be dereferenced.
+     *
+     * @return
+     *     An integer representing the status of of alias
+     *     dereferencing, as configured in guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getDereferenceAliases() throws GuacamoleException {
+        String derefAliases = environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_DEREFERENCE_ALIASES,
+            "never"
+        );
+
+        if (derefAliases == "always")
+            return 3;
+
+        else if (derefAliases == "finding")
+            return 2;
+
+        else if (derefAliases == "searching")
+            return 1;
+
+        else
+            return 0;
+
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -224,7 +224,7 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public int getMaxResults() throws GuacamoleException {
+    private int getMaxResults() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_MAX_SEARCH_RESULTS,
             1000 
@@ -234,7 +234,7 @@ public class ConfigurationService {
     /**
      * Returns whether or not LDAP aliases will be dereferenced,
      * as configured with guacamole.properties.  The default
-     * behavior if not explicityly defined is to never 
+     * behavior if not explicitly defined is to never 
      * dereference them.
      *
      * @return
@@ -244,21 +244,17 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public DereferenceAliases getDereferenceAliases() throws GuacamoleException {
+    private DereferenceAliasesMode getDereferenceAliases() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_DEREFERENCE_ALIASES,
-            DereferenceAliases.NEVER
+            DereferenceAliasesMode.NEVER
         );
 
     }
 
     /**
      * Returns a set of LDAPSearchConstraints to apply globally
-     * to all LDAP searches rather than having various instances
-     * dispersed throughout the code.  Currently contains the
-     * maximum number of LDAP results to return in a search, as
-     * well as whether or not aliases should be dereferenced
-     * during LDAP operations.
+     * to all LDAP searches.
      *
      * @return
      *     A LDAPSearchConstraints object containing constraints

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -225,12 +225,15 @@ public class ConfigurationService {
 
     /**
      * Returns whether or not LDAP aliases will be dereferenced,
-     * as configured with guacamole.properties.
-     * By default they will never be dereferenced.
+     * as configured with guacamole.properties.  The default
+     * behavior if not explicityly defined is to never 
+     * dereference them.
      *
      * @return
-     *     An integer representing the status of of alias
-     *     dereferencing, as configured in guacamole.properties.
+     *     An integer value that maps to the JLDAP constants
+     *     for dereferencing - 0 is DEREF_NEVER, 1 is DEREF_SEARCHING,
+     *     2 is DEREF_FINDING, and 3 is DEREF_ALWAYS - as configured
+     *     in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -233,8 +233,8 @@ public class ConfigurationService {
 
     /**
      * Returns whether or not LDAP aliases will be dereferenced,
-     * as configured with guacamole.properties.  The default
-     * behavior if not explicitly defined is to never 
+     * as configured with guacamole.properties. The default
+     * behavior if not explicitly defined is to never
      * dereference them.
      *
      * @return
@@ -249,7 +249,6 @@ public class ConfigurationService {
             LDAPGuacamoleProperties.LDAP_DEREFERENCE_ALIASES,
             DereferenceAliasesMode.NEVER
         );
-
     }
 
     /**

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -238,37 +238,17 @@ public class ConfigurationService {
      * dereference them.
      *
      * @return
-     *     An integer value that maps to the JLDAP constants
-     *     for dereferencing - 0 is DEREF_NEVER, 1 is DEREF_SEARCHING,
-     *     2 is DEREF_FINDING, and 3 is DEREF_ALWAYS - as configured
-     *     in guacamole.properties.
+     *     The behavior for handling dereferencing of aliases
+     *     as configured in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public int getDereferenceAliases() throws GuacamoleException {
-        String derefAliases = environment.getProperty(
+    public DereferenceAliases getDereferenceAliases() throws GuacamoleException {
+        return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_DEREFERENCE_ALIASES,
-            "never"
+            DereferenceAliases.NEVER
         );
-
-        if (derefAliases.equals("always"))
-            return 3;
-
-        else if (derefAliases.equals("finding"))
-            return 2;
-
-        else if (derefAliases.equals("searching"))
-            return 1;
-
-        else if (derefAliases.equals("never"))
-            return 0;
-        
-        else {
-            logger.error("Invalid value given for ldap-dereference-aliases.");
-            logger.debug("Received {} but expected one of the following: always, finding, searching, never.", derefAliases);
-            throw new GuacamoleException("Invalid valid for ldap-dereference-aliases.");
-        }
 
     }
 
@@ -292,7 +272,7 @@ public class ConfigurationService {
         LDAPSearchConstraints constraints = new LDAPSearchConstraints();
 
         constraints.setMaxResults(getMaxResults());
-        constraints.setDereference(getDereferenceAliases());
+        constraints.setDereference(getDereferenceAliases().DEREF_VALUE);
 
         return constraints;
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliases.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliases.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap;
+
+/**
+ * Acceptable values for configuring the dereferencing of aliases in
+ * talking to LDAP servers.
+ */
+public enum DereferenceAliases {
+
+    /**
+     * Never dereference aliases.  This is the default.
+     */
+    NEVER(0),
+
+    /**
+     * Aliases are dereferenced below the base object, but not to locate
+     * the base object itself.  So, if the base object is itself an alias
+     * the search will not complete.
+     */
+    SEARCHING(1),
+
+    /**
+     * Aliases are only dereferenced to locate the base object, but not
+     * after that.  So, a search against a base object that is an alias will
+     * find any subordinates of the real object the aliase references, but
+     * further aliases in the search will not be dereferenced.
+     */
+    FINDING(2),
+
+    /**
+     * Aliases will always be dereferenced, both to locate the base object
+     * and when handling results returned by the search.
+     */
+    ALWAYS(3);
+
+    /**
+     * The integer value that the enum represents, which is used in
+     * configuring the JLDAP library.
+     */
+    public final int DEREF_VALUE;
+
+    /**
+     * Initializes the dereference aliases object with the integer
+     * value the setting maps to per the JLDAP implementation.
+     *
+     * @param derefValue
+     *     The value associated with this dereference setting
+     */
+    private DereferenceAliases(int derefValue) {
+        this.DEREF_VALUE = derefValue;
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesMode.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesMode.java
@@ -28,20 +28,20 @@ import com.novell.ldap.LDAPSearchConstraints;
 public enum DereferenceAliasesMode {
 
     /**
-     * Never dereference aliases.  This is the default.
+     * Never dereference aliases. This is the default.
      */
     NEVER(LDAPSearchConstraints.DEREF_NEVER),
 
     /**
      * Aliases are dereferenced below the base object, but not to locate
-     * the base object itself.  So, if the base object is itself an alias
+     * the base object itself. So, if the base object is itself an alias
      * the search will not complete.
      */
     SEARCHING(LDAPSearchConstraints.DEREF_SEARCHING),
 
     /**
      * Aliases are only dereferenced to locate the base object, but not
-     * after that.  So, a search against a base object that is an alias will
+     * after that. So, a search against a base object that is an alias will
      * find any subordinates of the real object the alias references, but
      * further aliases in the search will not be dereferenced.
      */

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesMode.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesMode.java
@@ -19,41 +19,44 @@
 
 package org.apache.guacamole.auth.ldap;
 
+import com.novell.ldap.LDAPSearchConstraints;
+
 /**
- * Acceptable values for configuring the dereferencing of aliases in
- * talking to LDAP servers.
+ * Data type that handles acceptable values for configuring
+ * alias dereferencing behavior when querying LDAP servers.
  */
-public enum DereferenceAliases {
+public enum DereferenceAliasesMode {
 
     /**
      * Never dereference aliases.  This is the default.
      */
-    NEVER(0),
+    NEVER(LDAPSearchConstraints.DEREF_NEVER),
 
     /**
      * Aliases are dereferenced below the base object, but not to locate
      * the base object itself.  So, if the base object is itself an alias
      * the search will not complete.
      */
-    SEARCHING(1),
+    SEARCHING(LDAPSearchConstraints.DEREF_SEARCHING),
 
     /**
      * Aliases are only dereferenced to locate the base object, but not
      * after that.  So, a search against a base object that is an alias will
-     * find any subordinates of the real object the aliase references, but
+     * find any subordinates of the real object the alias references, but
      * further aliases in the search will not be dereferenced.
      */
-    FINDING(2),
+    FINDING(LDAPSearchConstraints.DEREF_FINDING),
 
     /**
      * Aliases will always be dereferenced, both to locate the base object
      * and when handling results returned by the search.
      */
-    ALWAYS(3);
+    ALWAYS(LDAPSearchConstraints.DEREF_ALWAYS);
 
     /**
-     * The integer value that the enum represents, which is used in
-     * configuring the JLDAP library.
+     * The integer constant as defined in the JLDAP library that
+     * the LDAPSearchConstraints class uses to define the
+     * dereferencing behavior during search operations.
      */
     public final int DEREF_VALUE;
 
@@ -64,7 +67,7 @@ public enum DereferenceAliases {
      * @param derefValue
      *     The value associated with this dereference setting
      */
-    private DereferenceAliases(int derefValue) {
+    private DereferenceAliasesMode(int derefValue) {
         this.DEREF_VALUE = derefValue;
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
@@ -26,7 +26,7 @@ import org.apache.guacamole.properties.GuacamoleProperty;
 /**
  * A GuacamoleProperty with a value of DereferenceAliases. The possible strings
  * "never", "searching", "finding", and "always" are mapped to their values as a
- * DereferenceAliases enum.  Anything else results in a parse error.
+ * DereferenceAliases enum. Anything else results in a parse error.
  */
 public abstract class DereferenceAliasesProperty implements GuacamoleProperty<DereferenceAliasesMode> {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
@@ -28,10 +28,10 @@ import org.apache.guacamole.properties.GuacamoleProperty;
  * "never", "searching", "finding", and "always" are mapped to their values as a
  * DereferenceAliases enum.  Anything else results in a parse error.
  */
-public abstract class DereferenceAliasesProperty implements GuacamoleProperty<DereferenceAliases> {
+public abstract class DereferenceAliasesProperty implements GuacamoleProperty<DereferenceAliasesMode> {
 
     @Override
-    public DereferenceAliases parseValue(String value) throws GuacamoleException {
+    public DereferenceAliasesMode parseValue(String value) throws GuacamoleException {
 
         // No value provided, so return null.
         if (value == null)
@@ -39,19 +39,19 @@ public abstract class DereferenceAliasesProperty implements GuacamoleProperty<De
 
         // Never dereference aliases
         if (value.equals("never"))
-            return DereferenceAliases.NEVER;
+            return DereferenceAliasesMode.NEVER;
 
         // Dereference aliases during search operations, but not at base
         if (value.equals("searching"))
-            return DereferenceAliases.SEARCHING;
+            return DereferenceAliasesMode.SEARCHING;
 
         // Dereference aliases to locate base, but not during searches
         if (value.equals("finding"))
-            return DereferenceAliases.FINDING;
+            return DereferenceAliasesMode.FINDING;
 
         // Always dereference aliases
         if (value.equals("always"))
-            return DereferenceAliases.ALWAYS;
+            return DereferenceAliasesMode.ALWAYS;
 
         // Anything else is invalid and results in an error
         throw new GuacamoleServerException("Dereference aliases must be one of \"never\", \"searching\", \"finding\", or \"always\".");

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/DereferenceAliasesProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.properties.GuacamoleProperty;
+
+/**
+ * A GuacamoleProperty with a value of DereferenceAliases. The possible strings
+ * "never", "searching", "finding", and "always" are mapped to their values as a
+ * DereferenceAliases enum.  Anything else results in a parse error.
+ */
+public abstract class DereferenceAliasesProperty implements GuacamoleProperty<DereferenceAliases> {
+
+    @Override
+    public DereferenceAliases parseValue(String value) throws GuacamoleException {
+
+        // No value provided, so return null.
+        if (value == null)
+            return null;
+
+        // Never dereference aliases
+        if (value.equals("never"))
+            return DereferenceAliases.NEVER;
+
+        // Dereference aliases during search operations, but not at base
+        if (value.equals("searching"))
+            return DereferenceAliases.SEARCHING;
+
+        // Dereference aliases to locate base, but not during searches
+        if (value.equals("finding"))
+            return DereferenceAliases.FINDING;
+
+        // Always dereference aliases
+        if (value.equals("always"))
+            return DereferenceAliases.ALWAYS;
+
+        // Anything else is invalid and results in an error
+        throw new GuacamoleServerException("Dereference aliases must be one of \"never\", \"searching\", \"finding\", or \"always\".");
+
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -154,7 +154,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * The behavior of alias dereferncing for the LDAP connections.
+     * The behavior of alias dereferencing for the LDAP connections.
      */
     public static final StringGuacamoleProperty LDAP_DEREFERENCE_ALIASES = new StringGuacamoleProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -154,7 +154,8 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * The behavior of alias dereferencing for the LDAP connections.
+     * Property that controls whether or not the LDAP connection follows
+     * (dereferences) aliases as it searches the tree.
      */
     public static final DereferenceAliasesProperty LDAP_DEREFERENCE_ALIASES = new DereferenceAliasesProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -156,7 +156,7 @@ public class LDAPGuacamoleProperties {
     /**
      * The behavior of alias dereferencing for the LDAP connections.
      */
-    public static final StringGuacamoleProperty LDAP_DEREFERENCE_ALIASES = new StringGuacamoleProperty() {
+    public static final DereferenceAliasesProperty LDAP_DEREFERENCE_ALIASES = new DereferenceAliasesProperty() {
 
         @Override
         public String getName() { return "ldap-dereference-aliases"; }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -153,4 +153,14 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * The behavior of alias dereferncing for the LDAP connections.
+     */
+    public static final StringGuacamoleProperty LDAP_DEREFERENCE_ALIASES = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-dereference-aliases"; }
+
+    };
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -24,6 +24,7 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPSearchConstraints;
 import com.novell.ldap.LDAPSearchResults;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -108,6 +109,10 @@ public class ConnectionService {
             // current user
             String connectionSearchFilter = getConnectionSearchFilter(userDN, ldapConnection);
 
+            // Set Search Constraints
+            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+            constraints.setDereference(confService.getDereferenceAliases());
+
             // Find all Guacamole connections for the given user by
             // looking for direct membership in the guacConfigGroup
             // and possibly any groups the user is a member of that are
@@ -117,7 +122,8 @@ public class ConnectionService {
                 LDAPConnection.SCOPE_SUB,
                 connectionSearchFilter,
                 null,
-                false
+                false,
+                constraints
             );
 
             // Build token filter containing credential tokens
@@ -234,13 +240,18 @@ public class ConnectionService {
         String groupBaseDN = confService.getGroupBaseDN();
         if (groupBaseDN != null) {
 
+            // Set up LDAP constraints
+            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+            constraints.setDereference(confService.getDereferenceAliases());
+
             // Get all groups the user is a member of starting at the groupBaseDN, excluding guacConfigGroups
             LDAPSearchResults userRoleGroupResults = ldapConnection.search(
                 groupBaseDN,
                 LDAPConnection.SCOPE_SUB,
                 "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
                 null,
-                false
+                false,
+                constraints
             );
 
             // Append the additional user groups to the LDAP filter

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -24,7 +24,6 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
-import com.novell.ldap.LDAPSearchConstraints;
 import com.novell.ldap.LDAPSearchResults;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -109,10 +108,6 @@ public class ConnectionService {
             // current user
             String connectionSearchFilter = getConnectionSearchFilter(userDN, ldapConnection);
 
-            // Set Search Constraints
-            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
-            constraints.setDereference(confService.getDereferenceAliases());
-
             // Find all Guacamole connections for the given user by
             // looking for direct membership in the guacConfigGroup
             // and possibly any groups the user is a member of that are
@@ -123,7 +118,7 @@ public class ConnectionService {
                 connectionSearchFilter,
                 null,
                 false,
-                constraints
+                confService.getLDAPSearchConstraints()
             );
 
             // Build token filter containing credential tokens
@@ -240,10 +235,6 @@ public class ConnectionService {
         String groupBaseDN = confService.getGroupBaseDN();
         if (groupBaseDN != null) {
 
-            // Set up LDAP constraints
-            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
-            constraints.setDereference(confService.getDereferenceAliases());
-
             // Get all groups the user is a member of starting at the groupBaseDN, excluding guacConfigGroups
             LDAPSearchResults userRoleGroupResults = ldapConnection.search(
                 groupBaseDN,
@@ -251,7 +242,7 @@ public class ConnectionService {
                 "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
                 null,
                 false,
-                constraints
+                confService.getLDAPSearchConstraints()
             );
 
             // Append the additional user groups to the LDAP filter

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -25,7 +25,6 @@ import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPSearchResults;
-import com.novell.ldap.LDAPSearchConstraints;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,10 +84,6 @@ public class UserService {
             String usernameAttribute) throws GuacamoleException {
 
         try {
-            // Set search limits
-            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
-            constraints.setMaxResults(confService.getMaxResults());
-            constraints.setDereference(confService.getDereferenceAliases());
 
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
@@ -97,7 +92,7 @@ public class UserService {
                 "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*))",
                 null,
                 false,
-                constraints
+                confService.getLDAPSearchConstraints()
             );
 
             // Read all visible users
@@ -248,9 +243,6 @@ public class UserService {
 
             List<String> userDNs = new ArrayList<String>();
 
-            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
-            constraints.setDereference(confService.getDereferenceAliases());
-
             // Find all Guacamole users underneath base DN and matching the
             // specified username
             LDAPSearchResults results = ldapConnection.search(
@@ -259,7 +251,7 @@ public class UserService {
                 generateLDAPQuery(username),
                 null,
                 false,
-                constraints
+                confService.getLDAPSearchConstraints()
             );
 
             // Add all DNs for found users

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -88,6 +88,7 @@ public class UserService {
             // Set search limits
             LDAPSearchConstraints constraints = new LDAPSearchConstraints();
             constraints.setMaxResults(confService.getMaxResults());
+            constraints.setDereference(confService.getDereferenceAliases());
 
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
@@ -247,6 +248,9 @@ public class UserService {
 
             List<String> userDNs = new ArrayList<String>();
 
+            LDAPSearchConstraints constraints = new LDAPSearchConstraints();
+            constraints.setDereference(confService.getDereferenceAliases());
+
             // Find all Guacamole users underneath base DN and matching the
             // specified username
             LDAPSearchResults results = ldapConnection.search(
@@ -254,7 +258,8 @@ public class UserService {
                 LDAPConnection.SCOPE_SUB,
                 generateLDAPQuery(username),
                 null,
-                false
+                false,
+                constraints
             );
 
             // Add all DNs for found users


### PR DESCRIPTION
This adds the necessary code to allow the user to configure how the LDAP extension behaves with regard to dereferencing aliases.