### PR TITLE
GUACAMOLE-101: Allow Filtering of LDAP Users

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -275,12 +275,12 @@ public class ConfigurationService {
     /**
      * Returns the search filter that should be used when querying the
      * LDAP server for Guacamole users.  If no filter is specified,
-     * a default of objectClass=* is returned.
+     * a default of "(objectClass=*)" is returned.
      *
      * @return
      *     The search filter that should be used when querying the
      *     LDAP server for users that are valid in Guacamole, or
-     *     objectClass=* if not specified.
+     *     "(objectClass=*)" if not specified.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -295,12 +295,12 @@ public class ConfigurationService {
     /**
      * Returns the search filter that should be used when querying the 
      * LDAP server for Guacamole connections.  If no filter is specified,
-     * null is returned.
+     * the default of objectClass=guacConfigGroup is returned.
      * 
      * @return
      *     The search filter that should be used when querying the 
      *     LDAP server for connections for Guacamole, or 
-     *     null if no filter is specified. 
+     *     objectClass=guacConfigGroup if no filter is specified. 
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -292,24 +292,4 @@ public class ConfigurationService {
         );
     }
 
-    /**
-     * Returns the search filter that should be used when querying the 
-     * LDAP server for Guacamole connections.  If no filter is specified,
-     * the default of objectClass=guacConfigGroup is returned.
-     * 
-     * @return
-     *     The search filter that should be used when querying the 
-     *     LDAP server for connections for Guacamole, or 
-     *     objectClass=guacConfigGroup if no filter is specified. 
-     *
-     * @throws GuacamoleException
-     *     If guacamole.properties cannot be parsed.
-     */
-    public String getConnectionSearchFilter() throws GuacamoleException {
-        return environment.getProperty(
-            LDAPGuacamoleProperties.LDAP_CONNECTION_SEARCH_FILTER,
-            "(objectClass=guacConfigGroup)"
-        );
-    }
-
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -270,7 +270,46 @@ public class ConfigurationService {
         constraints.setDereference(getDereferenceAliases().DEREF_VALUE);
 
         return constraints;
+    }
 
+    /**
+     * Returns the search filter that should be used when querying the
+     * LDAP server for Guacamole users.  If no filter is specified,
+     * a default of objectClass=* is returned.
+     *
+     * @return
+     *     The search filter that should be used when querying the
+     *     LDAP server for users that are valid in Guacamole, or
+     *     objectClass=* if not specified.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getUserSearchFilter() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_USER_SEARCH_FILTER,
+            "(objectClass=*)"
+        );
+    }
+
+    /**
+     * Returns the search filter that should be used when querying the 
+     * LDAP server for Guacamole connections.  If no filter is specified,
+     * null is returned.
+     * 
+     * @return
+     *     The search filter that should be used when querying the 
+     *     LDAP server for connections for Guacamole, or 
+     *     null if no filter is specified. 
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getConnectionSearchFilter() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_CONNECTION_SEARCH_FILTER,
+            "(objectClass=guacConfigGroup)"
+        );
     }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -165,7 +165,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * A search filter to apply to the user LDAP query.
+     * A search filter to apply to user LDAP queries.
      */
     public static final StringGuacamoleProperty LDAP_USER_SEARCH_FILTER = new StringGuacamoleProperty() {
 
@@ -175,7 +175,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * A search filter to apply to the connection LDAP query.
+     * A search filter to apply to connection LDAP queries.
      */
     public static final StringGuacamoleProperty LDAP_CONNECTION_SEARCH_FILTER = new StringGuacamoleProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -164,4 +164,24 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * A search filter to apply to the user LDAP query.
+     */
+    public static final StringGuacamoleProperty LDAP_USER_SEARCH_FILTER = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-user-search-filter"; }
+
+    };
+
+    /**
+     * A search filter to apply to the connection LDAP query.
+     */
+    public static final StringGuacamoleProperty LDAP_CONNECTION_SEARCH_FILTER = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-connection-search-filter"; }
+
+    };
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -174,14 +174,4 @@ public class LDAPGuacamoleProperties {
 
     };
 
-    /**
-     * A search filter to apply to connection LDAP queries.
-     */
-    public static final StringGuacamoleProperty LDAP_CONNECTION_SEARCH_FILTER = new StringGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "ldap-connection-search-filter"; }
-
-    };
-
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -227,9 +227,7 @@ public class ConnectionService {
         StringBuilder connectionSearchFilter = new StringBuilder();
 
         // Add the prefix to the search filter, prefix filter searches for guacConfigGroups with the userDN as the member attribute value
-        connectionSearchFilter.append("(&");
-        connectionSearchFilter.append(confService.getConnectionSearchFilter());
-        connectionSearchFilter.append("(|(member=");
+        connectionSearchFilter.append("(&(objectClass=guacConfigGroup)(|(member=");
         connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(userDN));
         connectionSearchFilter.append(")");
 
@@ -241,7 +239,7 @@ public class ConnectionService {
             LDAPSearchResults userRoleGroupResults = ldapConnection.search(
                 groupBaseDN,
                 LDAPConnection.SCOPE_SUB,
-                "(&(!" + confService.getConnectionSearchFilter() + ")(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
+                "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
                 null,
                 false,
                 confService.getLDAPSearchConstraints()

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -227,7 +227,9 @@ public class ConnectionService {
         StringBuilder connectionSearchFilter = new StringBuilder();
 
         // Add the prefix to the search filter, prefix filter searches for guacConfigGroups with the userDN as the member attribute value
-        connectionSearchFilter.append("(&(objectClass=guacConfigGroup)(|(member=");
+        connectionSearchFilter.append("(&");
+        connectionSearchFilter.append(confService.getConnectionSearchFilter());
+        connectionSearchFilter.append("(|(member=");
         connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(userDN));
         connectionSearchFilter.append(")");
 
@@ -239,7 +241,7 @@ public class ConnectionService {
             LDAPSearchResults userRoleGroupResults = ldapConnection.search(
                 groupBaseDN,
                 LDAPConnection.SCOPE_SUB,
-                "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
+                "(&(!" + confService.getConnectionSearchFilter() + ")(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
                 null,
                 false,
                 confService.getLDAPSearchConstraints()

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -85,11 +85,18 @@ public class UserService {
 
         try {
 
+            StringBuilder userSearchFilter = new StringBuilder();
+            userSearchFilter.append("(&");
+            userSearchFilter.append(confService.getUserSearchFilter());
+            userSearchFilter.append("(" + escapeService.escapeLDAPSearchFilter(usernameAttribute) + "=*)");
+            userSearchFilter.append(")");
+         
+
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
                 confService.getUserBaseDN(),
                 LDAPConnection.SCOPE_SUB,
-                "(&(objectClass=*)(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*))",
+                userSearchFilter.toString(),
                 null,
                 false,
                 confService.getLDAPSearchConstraints()
@@ -189,7 +196,9 @@ public class UserService {
 
         // Build LDAP query for users having at least one username attribute
         // with the specified username as its value
-        StringBuilder ldapQuery = new StringBuilder("(&(objectClass=*)");
+        StringBuilder ldapQuery = new StringBuilder();
+        ldapQuery.append("(&");
+        ldapQuery.append(confService.getUserSearchFilter());
 
         // Include all attributes within OR clause if there are more than one
         if (usernameAttributes.size() > 1)

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -92,10 +92,8 @@ public class UserService {
             userSearchFilter.append(confService.getUserSearchFilter());
             userSearchFilter.append("(");
             userSearchFilter.append(escapingService.escapeLDAPSearchFilter(usernameAttribute));
-            userSearchFilter.append("=*)");
-            userSearchFilter.append(")");
+            userSearchFilter.append("=*))");
          
-
             // Find all Guacamole users underneath base DN
             LDAPSearchResults results = ldapConnection.search(
                 confService.getUserBaseDN(),

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -90,7 +90,9 @@ public class UserService {
             StringBuilder userSearchFilter = new StringBuilder();
             userSearchFilter.append("(&");
             userSearchFilter.append(confService.getUserSearchFilter());
-            userSearchFilter.append("(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)");
+            userSearchFilter.append("(");
+            userSearchFilter.append(escapingService.escapeLDAPSearchFilter(usernameAttribute));
+            userSearchFilter.append("=*)");
             userSearchFilter.append(")");
          
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -85,10 +85,12 @@ public class UserService {
 
         try {
 
+            // Build a filter using the configured or default user search filter
+            // to find all user objects in the LDAP tree
             StringBuilder userSearchFilter = new StringBuilder();
             userSearchFilter.append("(&");
             userSearchFilter.append(confService.getUserSearchFilter());
-            userSearchFilter.append("(" + escapeService.escapeLDAPSearchFilter(usernameAttribute) + "=*)");
+            userSearchFilter.append("(" + escapingService.escapeLDAPSearchFilter(usernameAttribute) + "=*)");
             userSearchFilter.append(")");
          
 
@@ -195,7 +197,7 @@ public class UserService {
         List<String> usernameAttributes = confService.getUsernameAttributes();
 
         // Build LDAP query for users having at least one username attribute
-        // with the specified username as its value
+        // and with the configured or default search filter
         StringBuilder ldapQuery = new StringBuilder();
         ldapQuery.append("(&");
         ldapQuery.append(confService.getUserSearchFilter());


### PR DESCRIPTION
Took a stab at implementing two LDAP filter configuration properties for user and connection searches.

This was a very quick stab at implementing it - there are a couple of things that might be worth adding:
- Error checking on the LDAP query - not sure if there's an easy way to parse out the filters to make sure that they're valid before actually running the searches??  The LDAPException should handle this - there are specific messages for filter errors.
- The JIRA issue mentions implementing multiple search bases - this does not do anything with that.