### PR TITLE
GUACAMOLE-252: Ensure display container is explicitly sized to cover the vertical area of its container.

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/display.css
+++ b/guacamole/src/main/webapp/app/client/styles/display.css
@@ -46,6 +46,7 @@ div.displayOuter {
 
 div.displayMiddle {
     width: 100%;
+    height: 100%;
     display: table-cell;
     vertical-align: middle;
     text-align: center;


### PR DESCRIPTION
It seems MS Edge does not always stretch `display: table-cell` elements to fit the vertical space of their `display: table` parents. This seems like a layout bug to me, but I can't find any confirmation from standards one way or the other.

In any case, explicitly specifying `height: 100%` makes things work as expected across the board.