### PR TITLE
GUACAMOLE-204: Do not display field headers, etc. if the field itself has no content.

### DIFF
--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -96,6 +96,17 @@ angular.module('form').directive('guacFormField', [function formField() {
 
             };
 
+            /**
+             * Returns whether the current field should be displayed.
+             *
+             * @returns {Boolean}
+             *     true if the current field should be displayed, false
+             *     otherwise.
+             */
+            $scope.isFieldVisible = function isFieldVisible() {
+                return fieldContent[0].hasChildNodes();
+            };
+
             // Update field contents when field definition is changed
             $scope.$watch('field', function setField(field) {
 

--- a/guacamole/src/main/webapp/app/form/templates/formField.html
+++ b/guacamole/src/main/webapp/app/form/templates/formField.html
@@ -1,10 +1,9 @@
-<label class="labeled-field" ng-class="{empty: !model}">
+<label class="labeled-field" ng-class="{empty: !model}" ng-show="isFieldVisible()">
 
     <!-- Field header -->
     <span class="field-header">{{getFieldHeader() | translate}}</span>
 
     <!-- Field content -->
-    <div class="form-field">
-    </div>
+    <div class="form-field"></div>
 
 </label>


### PR DESCRIPTION
As necessary for clean implementation of #121, as well anything else requiring an SSO-style field which does not render, this change ensures that `<guac-field>` will not actually display if the associated field has no content.