### PR TITLE
GUACAMOLE-250: Invoke client onsync only after display has flushed.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -1359,15 +1359,15 @@ Guacamole.Client = function(tunnel) {
                     currentTimestamp = timestamp;
                 }
 
+                // If received first update, no longer waiting.
+                if (currentState === STATE_WAITING)
+                    setState(STATE_CONNECTED);
+
+                // Call sync handler if defined
+                if (guac_client.onsync)
+                    guac_client.onsync(timestamp);
+
             });
-
-            // If received first update, no longer waiting.
-            if (currentState === STATE_WAITING)
-                setState(STATE_CONNECTED);
-
-            // Call sync handler if defined
-            if (guac_client.onsync)
-                guac_client.onsync(timestamp);
 
         },
 


### PR DESCRIPTION
The `onsync` handler of `Guacamole.Client` is intended to be invoked when a sync is received. Unfortunately, there is no guarantee that the display has actually finished rendering things at that time, so no display-related action can be performed as a result of that handler.

This change modifies the call to `onsync` so that there is such a guarantee. It will only be invoked once display flush has completed.