### PR TITLE
GUACAMOLE-250: Unblock image rendering tasks if image decode fails.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Display.js
+++ b/guacamole-common-js/src/main/webapp/modules/Display.js
@@ -548,13 +548,20 @@ Guacamole.Display = function() {
 
         // Draw and free blob URL when ready
         var task = scheduleTask(function __display_drawBlob() {
-            layer.drawImage(x, y, image);
+
+            // Draw the image only if it loaded without errors
+            if (image.width && image.height)
+                layer.drawImage(x, y, image);
+
+            // Blob URL no longer needed
             URL.revokeObjectURL(url);
+
         }, true);
 
         // Load image from URL
         var image = new Image();
         image.onload = task.unblock;
+        image.onerror = task.unblock;
         image.src = url;
 
     };
@@ -572,11 +579,16 @@ Guacamole.Display = function() {
     this.draw = function(layer, x, y, url) {
 
         var task = scheduleTask(function __display_draw() {
-            layer.drawImage(x, y, image);
+
+            // Draw the image only if it loaded without errors
+            if (image.width && image.height)
+                layer.drawImage(x, y, image);
+
         }, true);
 
         var image = new Image();
         image.onload = task.unblock;
+        image.onerror = task.unblock;
         image.src = url;
 
     };


### PR DESCRIPTION
Currently, Guacamole will permanently block the display from all further updates if image decoding fails (bad PNG, unsupported image format, etc.). This is potentially bad, as it would cause the connection to become visibly unresponsive.

This shouldn't happen in practice unless something is going horribly wrong within guacd, but it can easily happen when playing back screen recordings if those recordings contain images not supported by the browser handling playback (playing back a recording containing WebP images on Firefox, for example).