### PR TITLE
GUACAMOLE-250: Export client state asynchronously

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -196,8 +196,7 @@ Guacamole.Client = function(tunnel) {
             }
 
             // Invoke callback now that the state is ready
-            if (callback)
-                callback(state);
+            callback(state);
 
         });
 


### PR DESCRIPTION
Guacamole's protocol state and display state are asynchronous with respect to each other. A layer or buffer may have been deleted using a ["dispose" instruction](http://guacamole.incubator.apache.org/doc/gug/protocol-reference.html#dispose-instruction), for example, and thus cannot be referenced as far as the protocol is concerned, yet still exist within the display because the display has not yet flushed (it can be blocked by image decoding). This means that the current implementation of `exportState()` will not always function correctly, especially if the browser is decoding images slowly.

This change modifies `exportState()` such that it only returns the state object asynchronously (through invoking a callback), and populates the protocol and display portions of that state when they are available. A snapshot of layers and buffers present with respect to the protocol is taken immediately, and the data related to the layers and buffers in the snapshot is added to the state object once the display is ready.