### PR TITLE
GUACAMOLE-250: Ensure static downloads of Guacamole protocol data are handled as text.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -1139,6 +1139,7 @@ Guacamole.StaticHTTPTunnel = function StaticHTTPTunnel(url, crossDomain) {
         xhr = new XMLHttpRequest();
         xhr.open('GET', url);
         xhr.withCredentials = !!crossDomain;
+        xhr.responseType = 'text';
         xhr.send(null);
 
         var offset = 0;


### PR DESCRIPTION
If a static download of Guacamole protocol data is initiated using `Guacamole.StaticHTTPTunnel`, the web server may always not respond with a proper `Content-Type` header, in which case the browser will assume the content is XML and attempt to parse it as such.

Setting `responseType` to "text" forces the browser to only interpret the response as text, regardless of `Content-Type`, preventing unnecessary XML parsing attempts.