### PR TITLE
GUACAMOLE-208: Add exception classes for newly-defined status codes.

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleResourceClosedException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleResourceClosedException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which is thrown when a resource is no longer available because
+ * it is closed.
+ */
+public class GuacamoleResourceClosedException extends GuacamoleClientException {
+
+    /**
+     * Creates a new GuacamoleResourceClosedException with the given message
+     * and cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleResourceClosedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleResourceClosedException with the given message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleResourceClosedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleResourceClosedException with the given cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleResourceClosedException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.RESOURCE_CLOSED;
+    }
+
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionClosedException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionClosedException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which indicates that a session within an upstream server (such
+ * as the remote desktop) has been forcibly terminated.
+ */
+public class GuacamoleSessionClosedException extends GuacamoleUpstreamException {
+
+    /**
+     * Creates a new GuacamoleSessionClosedException with the given message and
+     * cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionClosedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionClosedException with the given message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleSessionClosedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionClosedException with the given cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionClosedException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.SESSION_CLOSED;
+    }
+
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionConflictException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionConflictException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which indicates that a session within an upstream server (such
+ * as the remote desktop) has ended because it conflicted with another session.
+ */
+public class GuacamoleSessionConflictException extends GuacamoleUpstreamException {
+
+    /**
+     * Creates a new GuacamoleSessionConflictException with the given message
+     * and cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionConflictException with the given message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleSessionConflictException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionConflictException with the given cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionConflictException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.SESSION_CONFLICT;
+    }
+
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionTimeoutException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleSessionTimeoutException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which indicates that a session within an upstream server (such
+ * as the remote desktop) has ended because it appeared to be inactive.
+ */
+public class GuacamoleSessionTimeoutException extends GuacamoleUpstreamException {
+
+    /**
+     * Creates a new GuacamoleSessionTimeoutException with the given message
+     * and cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionTimeoutException with the given message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleSessionTimeoutException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleSessionTimeoutException with the given cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleSessionTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.SESSION_TIMEOUT;
+    }
+
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleUpstreamNotFoundException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleUpstreamNotFoundException.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which indicates that an upstream server (such as the remote
+ * desktop) does not appear to exist.
+ */
+public class GuacamoleUpstreamNotFoundException extends GuacamoleUpstreamException {
+
+    /**
+     * Creates a new GuacamoleUpstreamNotFoundException with the given message
+     * and cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleUpstreamNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleUpstreamNotFoundException with the given message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleUpstreamNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleUpstreamNotFoundException with the given cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleUpstreamNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.UPSTREAM_NOT_FOUND;
+    }
+
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleUpstreamUnavailableException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleUpstreamUnavailableException.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * An exception which indicates that an upstream server (such as the remote
+ * desktop) is not available to service the request.
+ */
+public class GuacamoleUpstreamUnavailableException extends GuacamoleUpstreamException {
+
+    /**
+     * Creates a new GuacamoleUpstreamUnavailableException with the given
+     * message and cause.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleUpstreamUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new GuacamoleUpstreamUnavailableException with the given
+     * message.
+     *
+     * @param message
+     *     A human readable description of the exception that occurred.
+     */
+    public GuacamoleUpstreamUnavailableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new GuacamoleUpstreamUnavailableException with the given
+     * cause.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public GuacamoleUpstreamUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return GuacamoleStatus.UPSTREAM_UNAVAILABLE;
+    }
+
+}


### PR DESCRIPTION
The newly-defined `UPSTREAM_NOT_FOUND`, `UPSTREAM_UNAVAILABLE`, `SESSION_CLOSED`, `SESSION_CONFLICT`, and `SESSION_TIMEOUT` (from #123) are missing corresponding `GuacamoleException` classes. This change defines those.

This change also adds an exception for the old `RESOURCE_CLOSED` status code, which has existed for some time but had no corresponding `GuacamoleException` class.