### PR TITLE
GUACAMOLE-267: Take remote desktop errors into account for balancing groups.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -488,7 +488,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
                 getUnconfiguredGuacamoleSocket(cleanupTask), config, info);
 
             // Assign and return new tunnel 
-            return activeConnection.assignGuacamoleTunnel(socket);
+            return activeConnection.assignGuacamoleTunnel(socket, socket.getConnectionID());
             
         }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -39,8 +39,10 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionModel;
 import org.apache.guacamole.auth.jdbc.connection.ConnectionRecordModel;
 import org.apache.guacamole.auth.jdbc.connection.ConnectionParameterModel;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceConflictException;
 import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.GuacamoleSecurityException;
+import org.apache.guacamole.GuacamoleUpstreamException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
 import org.apache.guacamole.auth.jdbc.connection.ConnectionMapper;
 import org.apache.guacamole.environment.Environment;
@@ -60,6 +62,9 @@ import org.apache.guacamole.auth.jdbc.sharingprofile.ModeledSharingProfile;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileParameterMapper;
 import org.apache.guacamole.auth.jdbc.sharingprofile.SharingProfileParameterModel;
 import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
+import org.apache.guacamole.protocol.FailoverGuacamoleSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -68,6 +73,11 @@ import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
  * implementation of concurrency rules is up to policy-specific subclasses.
  */
 public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelService {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(AbstractGuacamoleTunnelService.class);
 
     /**
      * The environment of the Guacamole server.
@@ -439,6 +449,10 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
      *     Information describing the Guacamole client connecting to the given
      *     connection.
      *
+     * @param interceptErrors
+     *     Whether errors from the upstream remote desktop should be
+     *     intercepted and rethrown as GuacamoleUpstreamExceptions.
+     *
      * @return
      *     A new GuacamoleTunnel which is configured and connected to the given
      *     connection.
@@ -448,7 +462,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
      *     while connection configuration information is being retrieved.
      */
     private GuacamoleTunnel assignGuacamoleTunnel(ActiveConnectionRecord activeConnection,
-            GuacamoleClientInformation info) throws GuacamoleException {
+            GuacamoleClientInformation info, boolean interceptErrors) throws GuacamoleException {
 
         // Record new active connection
         Runnable cleanupTask = new ConnectionCleanupTask(activeConnection);
@@ -487,8 +501,11 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
             ConfiguredGuacamoleSocket socket = new ConfiguredGuacamoleSocket(
                 getUnconfiguredGuacamoleSocket(cleanupTask), config, info);
 
-            // Assign and return new tunnel 
-            return activeConnection.assignGuacamoleTunnel(socket, socket.getConnectionID());
+            // Assign and return new tunnel
+            if (interceptErrors)
+                return activeConnection.assignGuacamoleTunnel(new FailoverGuacamoleSocket(socket), socket.getConnectionID());
+            else
+                return activeConnection.assignGuacamoleTunnel(socket, socket.getConnectionID());
             
         }
 
@@ -633,7 +650,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
         // Connect only if the connection was successfully acquired
         ActiveConnectionRecord connectionRecord = activeConnectionRecordProvider.get();
         connectionRecord.init(user, connection);
-        return assignGuacamoleTunnel(connectionRecord, info);
+        return assignGuacamoleTunnel(connectionRecord, info, false);
 
     }
 
@@ -653,29 +670,50 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
         if (connections.isEmpty())
             throw new GuacamoleSecurityException("Permission denied.");
 
-        // Acquire group
-        acquire(user, connectionGroup);
+        do {
 
-        // Attempt to acquire to any child
-        ModeledConnection connection;
-        try {
-            connection = acquire(user, connections);
-        }
+            // Acquire group
+            acquire(user, connectionGroup);
 
-        // Ensure connection group is always released if child acquire fails
-        catch (GuacamoleException e) {
-            release(user, connectionGroup);
-            throw e;
-        }
+            // Attempt to acquire to any child
+            ModeledConnection connection;
+            try {
+                connection = acquire(user, connections);
+            }
 
-        // If session affinity is enabled, prefer this connection going forward
-        if (connectionGroup.isSessionAffinityEnabled())
-            user.preferConnection(connection.getIdentifier());
+            // Ensure connection group is always released if child acquire fails
+            catch (GuacamoleException e) {
+                release(user, connectionGroup);
+                throw e;
+            }
 
-        // Connect to acquired child
-        ActiveConnectionRecord connectionRecord = activeConnectionRecordProvider.get();
-        connectionRecord.init(user, connectionGroup, connection);
-        return assignGuacamoleTunnel(connectionRecord, info);
+            try {
+
+                // Connect to acquired child
+                ActiveConnectionRecord connectionRecord = activeConnectionRecordProvider.get();
+                connectionRecord.init(user, connectionGroup, connection);
+                GuacamoleTunnel tunnel = assignGuacamoleTunnel(connectionRecord, info, connections.size() > 1);
+
+                // If session affinity is enabled, prefer this connection going forward
+                if (connectionGroup.isSessionAffinityEnabled())
+                    user.preferConnection(connection.getIdentifier());
+
+                return tunnel;
+
+            }
+
+            // If connection failed due to an upstream error, retry other
+            // connections
+            catch (GuacamoleUpstreamException e) {
+                logger.info("Upstream error intercepted for connection \"{}\". Failing over to next connection in group...", connection.getIdentifier());
+                logger.debug("Upstream remote desktop reported an error during connection.", e);
+                connections.remove(connection);
+            }
+
+        } while (!connections.isEmpty());
+
+        // All connection possibilities have been exhausted
+        throw new GuacamoleResourceConflictException("Cannot connect. All upstream connections are unavailable.");
 
     }
 
@@ -703,7 +741,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
                 definition.getSharingProfile());
 
         // Connect to shared connection described by the created record
-        GuacamoleTunnel tunnel = assignGuacamoleTunnel(connectionRecord, info);
+        GuacamoleTunnel tunnel = assignGuacamoleTunnel(connectionRecord, info, false);
 
         // Register tunnel, such that it is closed when the
         // SharedConnectionDefinition is invalidated

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
@@ -366,13 +366,17 @@ public class ActiveConnectionRecord implements ConnectionRecord {
      * given socket.
      *
      * @param socket
-     *     The ConfiguredGuacamoleSocket to use to create the tunnel associated
-     *     with this connection record.
-     * 
+     *     The GuacamoleSocket to use to create the tunnel associated with this
+     *     connection record.
+     *
+     * @param connectionID
+     *     The connection ID assigned to this connection by guacd.
+     *
      * @return
      *     The newly-created tunnel associated with this connection record.
      */
-    public GuacamoleTunnel assignGuacamoleTunnel(final ConfiguredGuacamoleSocket socket) {
+    public GuacamoleTunnel assignGuacamoleTunnel(final GuacamoleSocket socket,
+            String connectionID) {
 
         // Create tunnel with given socket
         this.tunnel = new AbstractGuacamoleTunnel() {
@@ -391,7 +395,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
 
         // Store connection ID of the primary connection only
         if (isPrimaryConnection())
-            this.connectionID = socket.getConnectionID();
+            this.connectionID = connectionID;
 
         // Return newly-created tunnel
         return this.tunnel;

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/FailoverGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/FailoverGuacamoleSocket.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.protocol;
+
+import java.util.List;
+import org.apache.guacamole.GuacamoleConnectionClosedException;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.io.GuacamoleReader;
+import org.apache.guacamole.io.GuacamoleWriter;
+import org.apache.guacamole.net.GuacamoleSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * GuacamoleSocket implementation which transparently switches between an
+ * underlying queue of available sockets when errors are encountered during
+ * the initial part of a connection (prior to first "sync").
+ */
+public class FailoverGuacamoleSocket implements GuacamoleSocket {
+
+    /**
+     * Logger for this class.
+     */
+    private Logger logger = LoggerFactory.getLogger(FailoverGuacamoleSocket.class);
+
+    /**
+     * A queue of available sockets. The full set of available sockets need not
+     * be known ahead of time.
+     */
+    public static interface SocketQueue {
+
+        /**
+         * Returns the next available socket in the queue, or null if no
+         * further sockets are available. This function will be invoked when an
+         * error occurs within the current socket, and will be invoked again if
+         * a GuacamoleException is thrown. Such repeated calls to this function
+         * will occur until errors cease or null is returned.
+         *
+         * @return
+         *     The next available socket in the queue, or null if no further
+         *     sockets are available.
+         *
+         * @throws GuacamoleException
+         *     If an error occurs preventing the next available socket from
+         *     being used.
+         */
+        GuacamoleSocket nextSocket() throws GuacamoleException;
+
+    }
+
+    /**
+     * The queue of available sockets provided when this FailoverGuacamoleSocket
+     * was created.
+     */
+    private final SocketQueue sockets;
+
+    /**
+     * The current socket being used, or null if no socket is available.
+     */
+    private GuacamoleSocket socket;
+
+    /**
+     * Creates a new FailoverGuacamoleSocket which pulls its sockets from the
+     * given SocketQueue. If an error occurs during the Guacamole connection,
+     * other sockets from the SocketQueue are tried, in order, until no error
+     * occurs.
+     *
+     * @param sockets
+     *     A SocketQueue which returns the sockets which should be used, in
+     *     order.
+     *
+     * @throws GuacamoleException
+     *     If errors prevent use of the sockets defined by the SocketQueue, and
+     *     no further sockets remain to be tried.
+     */
+    public FailoverGuacamoleSocket(SocketQueue sockets)
+            throws GuacamoleException {
+        this.sockets = sockets;
+        selectNextSocket();
+    }
+
+    private GuacamoleException tryNextSocket() {
+
+        try {
+            if (socket != null)
+                socket.close();
+        }
+        catch (GuacamoleException e) {
+            if (socket.isOpen())
+                logger.debug("Previous failed socket could not be closed.", e);
+        }
+
+        try {
+
+            socket = sockets.nextSocket();
+            if (socket == null)
+                return new GuacamoleServerException("No remaining sockets to try.");
+
+        }
+
+        catch (GuacamoleException e) {
+            if (tryNextSocket() != null)
+                return e;
+        }
+
+        return null;
+
+    }
+
+    private void selectNextSocket() throws GuacamoleException {
+        synchronized (sockets) {
+            GuacamoleException failure = tryNextSocket();
+            if (failure != null)
+                throw failure;
+        }
+    }
+
+    private class ErrorFilter implements GuacamoleFilter {
+
+        /**
+         * Whether a "sync" instruction has been read.
+         */
+        private boolean receivedSync = false;
+
+        @Override
+        public GuacamoleInstruction filter(GuacamoleInstruction instruction)
+                throws GuacamoleException {
+
+            // Ignore instructions after first sync is received
+            if (receivedSync)
+                return instruction;
+
+            String opcode = instruction.getOpcode();
+
+            if (opcode.equals("sync")) {
+                receivedSync = true;
+                return instruction;
+            }
+
+            if (opcode.equals("error"))
+                return handleError(instruction);
+
+            return instruction;
+
+        }
+
+        private GuacamoleInstruction handleError(GuacamoleInstruction instruction) {
+
+            // Ignore error instructions which are missing the status code
+            List<String> args = instruction.getArgs();
+            if (args.size() < 2) {
+                logger.debug("Ignoring \"error\" instruction without status code.");
+                return instruction;
+            }
+
+            int statusCode;
+            try {
+                statusCode = Integer.parseInt(args.get(1));
+            }
+            catch (NumberFormatException e) {
+                logger.debug("Ignoring \"error\" instruction with non-numeric status code.", e);
+                return instruction;
+            }
+
+            // Invalid status code
+            GuacamoleStatus status = GuacamoleStatus.fromGuacamoleStatusCode(statusCode);
+            if (status == null) {
+                logger.debug("Ignoring \"error\" instruction with unknown/invalid status code: {}", statusCode);
+                return instruction;
+            }
+
+            // Only handle error instructions related to the upstream remote desktop
+            switch (status) {
+
+                // Transparently connect to a different connection if upstream fails
+                case UPSTREAM_ERROR:
+                case UPSTREAM_NOT_FOUND:
+                case UPSTREAM_TIMEOUT:
+                case UPSTREAM_UNAVAILABLE:
+                    break;
+
+                // Allow error through otherwise
+                default:
+                    return instruction;
+
+            }
+
+            logger.debug("Overriding {} \"error\" instruction. Failing over to next connection...", status);
+
+            // Advance through remaining sockets until another functional socket
+            // is retrieved, or no more sockets remain
+            try {
+                selectNextSocket();
+                return null;
+            }
+
+            catch (GuacamoleException e) {
+                logger.debug("No sockets remain to be tried - giving up on failover.");
+            }
+
+            // Allow error through if not intercepting
+            return instruction;
+
+        }
+
+    }
+
+    /**
+     * GuacamoleReader which filters "error" instructions, transparently failing
+     * over to the next socket in the queue if an error is encountered. Read
+     * attempts are delegated to the GuacamoleReader of the current socket.
+     */
+    private final GuacamoleReader reader = new FilteredGuacamoleReader(new GuacamoleReader() {
+
+        @Override
+        public boolean available() throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    return false;
+
+                return socket.getReader().available();
+
+            }
+        }
+
+        @Override
+        public char[] read() throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    return null;
+
+                return socket.getReader().read();
+
+            }
+        }
+
+        @Override
+        public GuacamoleInstruction readInstruction()
+                throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    return null;
+
+                return socket.getReader().readInstruction();
+
+            }
+        }
+
+    }, new ErrorFilter());
+
+    /**
+     * GuacamoleWriter which delegates all write attempts to the GuacamoleWriter
+     * of the current socket.
+     */
+    private final GuacamoleWriter writer = new GuacamoleWriter() {
+
+        @Override
+        public void write(char[] chunk, int off, int len)
+                throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    throw new GuacamoleConnectionClosedException("No further sockets remaining in SocketQueue.");
+
+                socket.getWriter().write(chunk, off, len);
+
+            }
+        }
+
+        @Override
+        public void write(char[] chunk) throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    throw new GuacamoleConnectionClosedException("No further sockets remaining in SocketQueue.");
+
+                socket.getWriter().write(chunk);
+
+            }
+        }
+
+        @Override
+        public void writeInstruction(GuacamoleInstruction instruction)
+                throws GuacamoleException {
+            synchronized (sockets) {
+
+                if (socket == null)
+                    throw new GuacamoleConnectionClosedException("No further sockets remaining in SocketQueue.");
+
+                socket.getWriter().writeInstruction(instruction);
+
+            }
+        }
+
+    };
+
+    @Override
+    public GuacamoleReader getReader() {
+        return reader;
+    }
+
+    @Override
+    public GuacamoleWriter getWriter() {
+        return writer;
+    }
+
+    @Override
+    public void close() throws GuacamoleException {
+        synchronized (sockets) {
+            socket.close();
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        synchronized (sockets) {
+
+            if (socket == null)
+                return false;
+
+            return socket.isOpen();
+
+        }
+    }
+    
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
@@ -33,12 +33,18 @@ public class GuacamoleInstruction {
     /**
      * The opcode of this instruction.
      */
-    private String opcode;
+    private final String opcode;
 
     /**
      * All arguments of this instruction, in order.
      */
-    private List<String> args;
+    private final List<String> args;
+
+    /**
+     * The cached result of converting this GuacamoleInstruction to the format
+     * used by the Guacamole protocol.
+     */
+    private String protocolForm = null;
 
     /**
      * Creates a new GuacamoleInstruction having the given Operation and
@@ -91,31 +97,41 @@ public class GuacamoleInstruction {
      * Returns this GuacamoleInstruction in the form it would be sent over the
      * Guacamole protocol.
      *
-     * @return This GuacamoleInstruction in the form it would be sent over the
-     *         Guacamole protocol.
+     * @return
+     *     This GuacamoleInstruction in the form it would be sent over the
+     *     Guacamole protocol.
      */
     @Override
     public String toString() {
 
-        StringBuilder buff = new StringBuilder();
+        // Avoid rebuilding Guacamole protocol form of instruction if already
+        // known
+        if (protocolForm == null) {
 
-        // Write opcode
-        buff.append(opcode.length());
-        buff.append('.');
-        buff.append(opcode);
+            StringBuilder buff = new StringBuilder();
 
-        // Write argument values
-        for (String value : args) {
-            buff.append(',');
-            buff.append(value.length());
+            // Write opcode
+            buff.append(opcode.length());
             buff.append('.');
-            buff.append(value);
+            buff.append(opcode);
+
+            // Write argument values
+            for (String value : args) {
+                buff.append(',');
+                buff.append(value.length());
+                buff.append('.');
+                buff.append(value);
+            }
+
+            // Write terminator
+            buff.append(';');
+
+            // Cache result for future calls
+            protocolForm = buff.toString();
+
         }
 
-        // Write terminator
-        buff.append(';');
-
-        return buff.toString();
+        return protocolForm;
 
     }
 


### PR DESCRIPTION
This change adds a new object to guacamole-common, `FailoverGuacamoleSocket`, which watches for "error" instructions related to the upstream remote desktop while the Guacamole connection process occurs, and modifies the balancing group behavior of the database auth to use this class where applicable.

If an error is encountered, `FailoverGuacamoleSocket` intercepts that error, rethrowing it as a `GuacamoleUpstreamException` (or subclass). In the case of the database auth, this results in the connection transparently failing over to the next available connection in the group. From the user's perspective, everything just magically works.