### PR TITLE
GUACAMOLE-289: Allow extensions to provide their own REST services.

### DIFF
--- a/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
+++ b/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
@@ -63,6 +63,11 @@ public class DuoAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
+    public Object getResource() {
+        return null;
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
         return null;

--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
@@ -64,6 +64,11 @@ public class HTTPHeaderAuthenticationProvider implements AuthenticationProvider 
     }
 
     @Override
+    public Object getResource() {
+        return null;
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
@@ -71,6 +71,11 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
         return authProviderService.authenticateUser(this, credentials);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
@@ -137,6 +137,11 @@ public class SharedUserContext implements UserContext {
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return authProvider;
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -117,6 +117,11 @@ public class ModeledUserContext extends RestrictedObject
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return getCurrentUser().getModelAuthenticationProvider();
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
@@ -69,6 +69,11 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
+    public String getResource() {
+        return null;
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials) throws GuacamoleException {
 
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
@@ -160,6 +160,11 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
     }
 
     @Override
+    public String getResource() {
+        return null;
+    }
+
+    @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return authProvider;
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
@@ -41,6 +41,26 @@ public interface AuthenticationProvider {
     String getIdentifier();
 
     /**
+     * Returns an arbitrary REST resource. The REST resource returned must be
+     * properly annotated with JSR-311 annotations, and may serve as the root
+     * resource for any number of extension-specific REST resources which are
+     * unrelated to an authenticated user's session. The returned resource is
+     * ultimately exposed at ".../api/ext/IDENTIFIER/", where IDENTIFIER is the
+     * identifier of the AuthenticationProvider.
+     *
+     * REST resources which ARE related to an authenticated user's session
+     * should instead be returned from UserContext.getResource().
+     *
+     * @return
+     *     An arbitrary REST resource, annotated with JSR-311 annotations, or
+     *     null if no such resource is defined.
+     *
+     * @throws GuacamoleException
+     *     If the REST resource cannot be returned due to an error.
+     */
+    Object getResource() throws GuacamoleException;
+
+    /**
      * Returns an AuthenticatedUser representing the user authenticated by the
      * given credentials, if any.
      *

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
@@ -41,15 +41,17 @@ public interface AuthenticationProvider {
     String getIdentifier();
 
     /**
-     * Returns an arbitrary REST resource. The REST resource returned must be
-     * properly annotated with JSR-311 annotations, and may serve as the root
-     * resource for any number of extension-specific REST resources which are
-     * unrelated to an authenticated user's session. The returned resource is
-     * ultimately exposed at ".../api/ext/IDENTIFIER/", where IDENTIFIER is the
-     * identifier of the AuthenticationProvider.
+     * Returns an arbitrary REST resource representing this
+     * AuthenticationProvider. The REST resource returned must be properly
+     * annotated with JSR-311 annotations, and may serve as the root resource
+     * for any number of subresources. The returned resource is ultimately
+     * exposed at ".../api/ext/IDENTIFIER/", where IDENTIFIER is the identifier
+     * of this AuthenticationProvider.
      *
-     * REST resources which ARE related to an authenticated user's session
-     * should instead be returned from UserContext.getResource().
+     * REST resources returned by this function will be reachable by all users,
+     * regardless of whether they have authenticated. REST resources which
+     * must only be accessible by authenticated users should instead be returned
+     * from UserContext.getResource().
      *
      * @return
      *     An arbitrary REST resource, annotated with JSR-311 annotations, or

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -43,8 +43,9 @@ public interface UserContext {
      * properly annotated with JSR-311 annotations, and may serve as the root
      * resource for any number of extension-specific REST resources related to
      * an authenticated user's session. The returned resource is ultimately
-     * exposed at ".../api/session/data/IDENTIFIER/ext/", where IDENTIFIER is
-     * the identifier of the AuthenticationProvider.
+     * exposed at ".../api/session/ext/IDENTIFIER/", where IDENTIFIER is the
+     * identifier of the AuthenticationProvider associated with this
+     * UserContext.
      *
      * REST resources which are NOT related to an authenticated user's session
      * should instead be returned from AuthenticationProvider.getResource().

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -39,16 +39,18 @@ public interface UserContext {
     User self();
 
     /**
-     * Returns an arbitrary REST resource. The REST resource returned must be
-     * properly annotated with JSR-311 annotations, and may serve as the root
-     * resource for any number of extension-specific REST resources related to
-     * an authenticated user's session. The returned resource is ultimately
-     * exposed at ".../api/session/ext/IDENTIFIER/", where IDENTIFIER is the
-     * identifier of the AuthenticationProvider associated with this
-     * UserContext.
+     * Returns an arbitrary REST resource representing this UserContext. The
+     * REST resource returned must be properly annotated with JSR-311
+     * annotations, and may serve as the root resource for any number of
+     * subresources. The returned resource is ultimately exposed at
+     * ".../api/session/ext/IDENTIFIER/", where IDENTIFIER is the identifier of
+     * the AuthenticationProvider associated with this UserContext.
      *
-     * REST resources which are NOT related to an authenticated user's session
-     * should instead be returned from AuthenticationProvider.getResource().
+     * REST resources returned by this function will only be reachable by
+     * authenticated users with valid authentication tokens. REST resources
+     * which should be accessible by all users regardless of whether they have
+     * authenticated should instead be returned from
+     * AuthenticationProvider.getResource().
      *
      * @return
      *     An arbitrary REST resource, annotated with JSR-311 annotations, or

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -39,6 +39,26 @@ public interface UserContext {
     User self();
 
     /**
+     * Returns an arbitrary REST resource. The REST resource returned must be
+     * properly annotated with JSR-311 annotations, and may serve as the root
+     * resource for any number of extension-specific REST resources related to
+     * an authenticated user's session. The returned resource is ultimately
+     * exposed at ".../api/session/data/IDENTIFIER/ext/", where IDENTIFIER is
+     * the identifier of the AuthenticationProvider.
+     *
+     * REST resources which are NOT related to an authenticated user's session
+     * should instead be returned from AuthenticationProvider.getResource().
+     *
+     * @return
+     *     An arbitrary REST resource, annotated with JSR-311 annotations, or
+     *     null if no such resource is defined.
+     *
+     * @throws GuacamoleException
+     *     If the REST resource cannot be returned due to an error.
+     */
+    Object getResource() throws GuacamoleException;
+
+    /**
      * Returns the AuthenticationProvider which created this UserContext, which
      * may not be the same AuthenticationProvider that authenticated the user
      * associated with this UserContext.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -204,6 +204,11 @@ public abstract class SimpleAuthenticationProvider
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(final Credentials credentials)
             throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
@@ -164,6 +164,11 @@ public class SimpleUserContext implements UserContext {
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return authProvider;
     }

--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -135,6 +135,20 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
     }
 
     @Override
+    public Object getResource() throws GuacamoleException {
+
+        // Ignore auth attempts if no auth provider could be loaded
+        if (authProvider == null) {
+            logger.warn("The authentication system could not be loaded. Please check for errors earlier in the logs.");
+            return null;
+        }
+
+        // Delegate to underlying auth provider
+        return authProvider.getResource();
+
+    }
+
+    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTServiceModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTServiceModule.java
@@ -36,6 +36,7 @@ import org.apache.guacamole.rest.auth.SecureRandomAuthTokenGenerator;
 import org.apache.guacamole.rest.auth.TokenSessionMap;
 import org.apache.guacamole.rest.connection.ConnectionModule;
 import org.apache.guacamole.rest.connectiongroup.ConnectionGroupModule;
+import org.apache.guacamole.rest.extension.ExtensionRESTService;
 import org.apache.guacamole.rest.language.LanguageRESTService;
 import org.apache.guacamole.rest.patch.PatchRESTService;
 import org.apache.guacamole.rest.session.SessionResourceFactory;
@@ -84,6 +85,7 @@ public class RESTServiceModule extends ServletModule {
         bindInterceptor(Matchers.any(), new RESTMethodMatcher(), interceptor);
 
         // Set up the API endpoints
+        bind(ExtensionRESTService.class);
         bind(LanguageRESTService.class);
         bind(PatchRESTService.class);
         bind(TokenRESTService.class);

--- a/guacamole/src/main/java/org/apache/guacamole/rest/extension/ExtensionRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/extension/ExtensionRESTService.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.rest.extension;
+
+import com.google.inject.Inject;
+import java.util.List;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+
+/**
+ * A REST service which provides access to extension-specific REST resources,
+ * each exposed by the identifier of that extension's AuthenticationProvider.
+ */
+@Path("/ext")
+public class ExtensionRESTService {
+
+    /**
+     * All configured authentication providers.
+     */
+    @Inject
+    private List<AuthenticationProvider> authProviders;
+
+    /**
+     * Returns the AuthenticationProvider having the given identifier. If no
+     * such AuthenticationProvider has been loaded, null is returned.
+     *
+     * @param identifier
+     *     The identifier of the AuthenticationProvider to locate.
+     *
+     * @return
+     *     The AuthenticationProvider having the given identifier, or null if
+     *     no such AuthenticationProvider is loaded.
+     */
+    private AuthenticationProvider getAuthenticationProvider(String identifier) {
+
+        // Iterate through all installed AuthenticationProviders, searching for
+        // the given identifier
+        for (AuthenticationProvider authProvider : authProviders) {
+            if (authProvider.getIdentifier().equals(identifier))
+                return authProvider;
+        }
+
+        // No such AuthenticationProvider found
+        return null;
+
+    }
+
+    /**
+     * Returns the arbitrary REST resource exposed by the AuthenticationProvider
+     * having the given identifier.
+     *
+     * @param identifier
+     *     The identifier of the AuthenticationProvider whose REST resource
+     *     should be retrieved.
+     *
+     * @return
+     *     The arbitrary REST resource exposed by the AuthenticationProvider
+     *     having the given identifier.
+     *
+     * @throws GuacamoleException
+     *     If no such resource could be found, or if an error occurs while
+     *     retrieving that resource.
+     */
+    @Path("{identifier}")
+    public Object getExtensionResource(@PathParam("identifier") String identifier)
+            throws GuacamoleException {
+
+        // Retrieve authentication provider having given identifier
+        AuthenticationProvider authProvider = getAuthenticationProvider(identifier);
+        if (authProvider != null) {
+
+            // Pull resource from authentication provider
+            Object resource = authProvider.getResource();
+            if (resource != null)
+                return resource;
+
+        }
+
+        // AuthenticationProvider-specific resource could not be found
+        throw new GuacamoleResourceNotFoundException("No such resource.");
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/rest/extension/package-info.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/extension/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Classes related to the arbitrary REST services exposed by extensions.
+ */
+package org.apache.guacamole.rest.extension;

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/SessionResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/SessionResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.GuacamoleSession;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.rest.tunnel.TunnelCollectionResource;
@@ -98,6 +99,40 @@ public class SessionResource {
 
         // Return a resource exposing the retrieved UserContext
         return userContextResourceFactory.create(userContext);
+
+    }
+
+    /**
+     * Returns the arbitrary REST resource exposed by the UserContext
+     * associated with the AuthenticationProvider having the given identifier.
+     *
+     * @param authProviderIdentifier
+     *     The unique identifier of the AuthenticationProvider associated with
+     *     the UserContext whose arbitrary REST service is being retrieved.
+     *
+     * @return
+     *     The arbitrary REST resource exposed by the UserContext exposed by
+     *     this UserContextresource.
+     *
+     * @throws GuacamoleException
+     *     If no such resource could be found, or if an error occurs while
+     *     retrieving that resource.
+     */
+    @Path("ext/{dataSource}")
+    public Object getExtensionResource(
+            @PathParam("dataSource") String authProviderIdentifier)
+            throws GuacamoleException {
+
+        // Pull UserContext defined by the given auth provider identifier
+        UserContext userContext = session.getUserContext(authProviderIdentifier);
+
+        // Pull resource from user context
+        Object resource = userContext.getResource();
+        if (resource != null)
+            return resource;
+
+        // UserContext-specific resource could not be found
+        throw new GuacamoleResourceNotFoundException("No such resource.");
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
@@ -29,7 +29,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
@@ -252,31 +251,6 @@ public class UserContextResource {
     @Path("schema")
     public SchemaResource getSchemaResource() {
         return new SchemaResource(userContext);
-    }
-
-    /**
-     * Returns the arbitrary REST resource exposed by the UserContext exposed
-     * by this UserContextResource.
-     *
-     * @return
-     *     The arbitrary REST resource exposed by the UserContext exposed by
-     *     this UserContextresource.
-     *
-     * @throws GuacamoleException
-     *     If no such resource could be found, or if an error occurs while
-     *     retrieving that resource.
-     */
-    @Path("ext")
-    public Object getExtensionResource() throws GuacamoleException {
-
-        // Pull resource from user context
-        Object resource = userContext.getResource();
-        if (resource != null)
-            return resource;
-
-        // UserContext-specific resource could not be found
-        throw new GuacamoleResourceNotFoundException("No such resource.");
-
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
@@ -251,6 +252,31 @@ public class UserContextResource {
     @Path("schema")
     public SchemaResource getSchemaResource() {
         return new SchemaResource(userContext);
+    }
+
+    /**
+     * Returns the arbitrary REST resource exposed by the UserContext exposed
+     * by this UserContextResource.
+     *
+     * @return
+     *     The arbitrary REST resource exposed by the UserContext exposed by
+     *     this UserContextresource.
+     *
+     * @throws GuacamoleException
+     *     If no such resource could be found, or if an error occurs while
+     *     retrieving that resource.
+     */
+    @Path("ext")
+    public Object getExtensionResource() throws GuacamoleException {
+
+        // Pull resource from user context
+        Object resource = userContext.getResource();
+        if (resource != null)
+            return resource;
+
+        // UserContext-specific resource could not be found
+        throw new GuacamoleResourceNotFoundException("No such resource.");
+
     }
 
 }


### PR DESCRIPTION
This changes adds a `getResource()` function to both `AuthenticationProvider` and `UserContext` which can return an arbitrary REST service annotated with JSR-311 annotations (JAX-RS). The resource returned by `AuthenticationProvider` is available without authenticating with the extension, while the resource returned by `UserContext` implicitly requires authentication (there would be no `UserContext` instance to return it otherwise).