### PR TITLE
GUACAMOLE-281: Consider template GUACAMOLE_HOME in Docker image configuration sanity checks.

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -427,7 +427,7 @@ fi
 # Validate that at least one authentication backend is installed
 #
 
-if [ -z "$INSTALLED_AUTH" ]; then
+if [ -z "$INSTALLED_AUTH" -a -z "$GUACAMOLE_HOME_TEMPLATE" ]; then
     cat <<END
 FATAL: No authentication configured
 -------------------------------------------------------------------------------
@@ -435,7 +435,7 @@ The Guacamole Docker container needs at least one authentication mechanism in
 order to function, such as a MySQL database, PostgreSQL database, or LDAP
 directory.  Please specify at least the MYSQL_DATABASE or POSTGRES_DATABASE
 environment variables, or check Guacamole's Docker documentation regarding
-configuring LDAP.
+configuring LDAP and/or custom extensions.
 END
     exit 1;
 fi


### PR DESCRIPTION
The sanity check which verifies whether a Guacamole Docker container has at least one configured authentication mechanism shouldn't fail if a custom `GUACAMOLE_HOME` is being used.