### PR TITLE
GUACAMOLE-294: Fix an incorrectly positioned bracket.

### DIFF
--- a/guacamole/src/main/webapp/app/touch/directives/guacTouchDrag.js
+++ b/guacamole/src/main/webapp/app/touch/directives/guacTouchDrag.js
@@ -168,7 +168,7 @@ angular.module('touch').directive('guacTouchDrag', [function guacTouchDrag() {
                     // Signal end of drag gesture
                     if (inProgress && guacTouchDrag) {
                         $scope.$apply(function dragComplete() {
-                            if (guacTouchDrag(true, startX, startY, currentX, currentY, deltaX, deltaY === false))
+                            if (guacTouchDrag(true, startX, startY, currentX, currentY, deltaX, deltaY) === false)
                                 e.preventDefault();
                         });
                     }


### PR DESCRIPTION
I spotted this line where `deltaY` is strictly compared against false, which should never be true because `deltaY` is a number. I believe the correct behavior is the one expressed on line 153, where the result of the `guacTouchDrag` function is compared against false.

---

I found this issue through [lgtm.com](https://lgtm.com/projects/g/apache/incubator-guacamole-client/alerts/), a service that analyzes open-source code to look for potential problems. (Full disclosure: I work for the company that operates it.)