### PR TITLE
GUACAMOLE-295: Fix an incorrect comparison with NaN.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -121,7 +121,7 @@ Guacamole.Parser = function() {
 
                 // Parse length
                 var length = parseInt(buffer.substring(element_end+1, length_end));
-                if (length == NaN)
+                if (isNaN(length))
                     throw new Error("Non-numeric character in element length.");
 
                 // Calculate start of element


### PR DESCRIPTION
I spotted this check of a number against `NaN` that don't seem to be correct. In JavaScript `NaN` is not equal to anything, not even itself. I've fixed this check to use the built in `isNaN` function instead which should correctly check if the variable is `NaN`.

---

I found this issue through [lgtm.com](https://lgtm.com/projects/g/apache/incubator-guacamole-client/alerts/), a service that analyzes open-source code to look for potential problems. (Full disclosure: I work for the company that operates it.)