### PR TITLE
GUACAMOLE-301: Clear login interface if navigation succeeds.

### DIFF
--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -165,18 +165,17 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         $scope.expectedCredentials = error.expected;
     });
 
-    // Clear login screen if login was successful
-    $scope.$on('guacLogin', function loginSuccessful() {
-        $scope.loginHelpText = null;
-        $scope.acceptedCredentials = null;
-        $scope.expectedCredentials = null;
-    });
-
     // Update title and CSS class upon navigation
     $scope.$on('$routeChangeSuccess', function(event, current, previous) {
        
         // If the current route is available
         if (current.$$route) {
+
+            // Clear login screen if route change was successful (and thus
+            // login was either successful or not required)
+            $scope.loginHelpText = null;
+            $scope.acceptedCredentials = null;
+            $scope.expectedCredentials = null;
 
             // Set title
             var title = current.$$route.title;


### PR DESCRIPTION
From [GUACAMOLE-301](https://issues.apache.org/jira/browse/GUACAMOLE-301):

>
> The current login screen logic displays the prompt if credentials are requested and clears the prompt once login is successful, but this is partially incorrect. If the user navigates to a page which does not require authentication (such as one exposed by an extension), the login prompt will persist unless the entire interface is reloaded.
>
> Because visiting a page will immediately result in credentials being requested if login is required, the login prompt should simply be cleared upon successful navigation.
>