### PR TITLE
GUACAMOLE-292: Restrict editing of attributes based on permissions.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -97,9 +97,12 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *
      * @return
      *     An object which is backed by the given model object.
+     *
+     * @throws GuacamoleException
+     *     If the object instance cannot be created.
      */
     protected abstract InternalType getObjectInstance(ModeledAuthenticatedUser currentUser,
-            ModelType model);
+            ModelType model) throws GuacamoleException;
 
     /**
      * Returns an instance of a model object which is based on the given
@@ -113,9 +116,12 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      *
      * @return
      *     A model object which is based on the given object.
+     *
+     * @throws GuacamoleException
+     *     If the model object instance cannot be created.
      */
     protected abstract ModelType getModelInstance(ModeledAuthenticatedUser currentUser,
-            ExternalType object);
+            ExternalType object) throws GuacamoleException;
 
     /**
      * Returns whether the given user has permission to create the type of
@@ -199,9 +205,12 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
      * @return
      *     A collection of objects which are backed by the models in the given
      *     collection.
+     *
+     * @throws GuacamoleException
+     *     If any of the object instances cannot be created.
      */
     protected Collection<InternalType> getObjectInstances(ModeledAuthenticatedUser currentUser,
-            Collection<ModelType> models) {
+            Collection<ModelType> models) throws GuacamoleException {
 
         // Create new collection of objects by manually converting each model
         Collection<InternalType> objects = new ArrayList<InternalType>(models.size());

--- a/guacamole/src/main/webapp/app/form/directives/form.js
+++ b/guacamole/src/main/webapp/app/form/directives/form.js
@@ -55,7 +55,16 @@ angular.module('form').directive('guacForm', [function form() {
              *
              * @type Object.<String, String>
              */
-            model : '='
+            model : '=',
+
+            /**
+             * Whether the contents of the form should be restricted to those
+             * fields/forms which match properties defined within the given
+             * model object. By default, all fields will be shown.
+             *
+             * @type Boolean
+             */
+            modelOnly : '='
 
         },
         templateUrl: 'app/form/templates/form.html',
@@ -162,6 +171,55 @@ angular.module('form').directive('guacForm', [function form() {
                     $scope.values = {};
 
             });
+
+            /**
+             * Returns whether the given field should be displayed to the
+             * current user.
+             *
+             * @param {Field} field
+             *     The field to check.
+             *
+             * @returns {Boolean}
+             *     true if the given field should be visible, false otherwise.
+             */
+            $scope.isVisible = function isVisible(field) {
+
+                // All fields are visible if contents are not restricted to
+                // model properties only
+                if (!$scope.modelOnly)
+                    return true;
+
+                // Otherwise, fields are only visible if they are present
+                // within the model
+                return field && (field.name in $scope.values);
+
+            };
+
+            /**
+             * Returns whether at least one of the given fields should be
+             * displayed to the current user.
+             *
+             * @param {Field[]} fields
+             *     The array of fields to check.
+             *
+             * @returns {Boolean}
+             *     true if at least one field within the given array should be
+             *     visible, false otherwise.
+             */
+            $scope.containsVisible = function containsVisible(fields) {
+
+                // If fields are defined, check whether at least one is visible
+                if (fields) {
+                    for (var i = 0; i < fields.length; i++) {
+                        if ($scope.isVisible(fields[i]))
+                            return true;
+                    }
+                }
+
+                // Otherwise, there are no visible fields
+                return false;
+
+            };
 
         }] // end controller
     };

--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -1,5 +1,6 @@
 <div class="form-group">
-    <div ng-repeat="form in forms" class="form">
+    <div ng-repeat="form in forms" class="form"
+         ng-show="containsVisible(form.fields)">
 
         <!-- Form name -->
         <h3 ng-show="form.name">{{getSectionHeader(form) | translate}}</h3>
@@ -7,6 +8,7 @@
         <!-- All fields in form -->
         <div class="fields">
             <guac-form-field ng-repeat="field in form.fields" namespace="namespace"
+                             ng-show="isVisible(field)"
                              field="field" model="values[field.name]"></guac-form-field>
         </div>
 

--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -8,7 +8,7 @@
         <!-- All fields in form -->
         <div class="fields">
             <guac-form-field ng-repeat="field in form.fields" namespace="namespace"
-                             ng-show="isVisible(field)"
+                             ng-if="isVisible(field)"
                              field="field" model="values[field.name]"></guac-form-field>
         </div>
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -300,6 +300,23 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     }
 
     /**
+     * Returns whether the current user can change/set all connection
+     * attributes for the connection being edited, regardless of whether those
+     * attributes are already explicitly associated with that connection.
+     *
+     * @returns {Boolean}
+     *     true if the current user can change all attributes for the
+     *     connection being edited, regardless of whether those attributes are
+     *     already explicitly associated with that connection, false otherwise.
+     */
+    $scope.canChangeAllAttributes = function canChangeAllAttributes() {
+
+        // All attributes can be set if we are creating the connection
+        return !identifier;
+
+    };
+
+    /**
      * Returns the translation string namespace for the protocol having the
      * given name. The namespace will be of the form:
      *

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -195,7 +195,26 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
             value : ConnectionGroup.Type.BALANCING
         }
     ];
-    
+
+    /**
+     * Returns whether the current user can change/set all connection group
+     * attributes for the connection group being edited, regardless of whether
+     * those attributes are already explicitly associated with that connection
+     * group.
+     *
+     * @returns {Boolean}
+     *     true if the current user can change all attributes for the
+     *     connection group being edited, regardless of whether those
+     *     attributes are already explicitly associated with that connection
+     *     group, false otherwise.
+     */
+    $scope.canChangeAllAttributes = function canChangeAllAttributes() {
+
+        // All attributes can be set if we are creating the connection group
+        return !identifier;
+
+    };
+
     /**
      * Cancels all pending edits, returning to the management page.
      */

--- a/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
@@ -281,6 +281,25 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
     });
 
     /**
+     * Returns whether the current user can change/set all sharing profile
+     * attributes for the sharing profile being edited, regardless of whether
+     * those attributes are already explicitly associated with that sharing
+     * profile.
+     *
+     * @returns {Boolean}
+     *     true if the current user can change all attributes for the sharing
+     *     profile being edited, regardless of whether those attributes are
+     *     already explicitly associated with that sharing profile, false
+     *     otherwise.
+     */
+    $scope.canChangeAllAttributes = function canChangeAllAttributes() {
+
+        // All attributes can be set if we are creating the sharing profile
+        return !identifier;
+
+    };
+
+    /**
      * Returns the translation string namespace for the protocol having the
      * given name. The namespace will be of the form:
      *

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -225,8 +225,8 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     };
 
     /**
-     * Returns whether the current user can change attributes associated with
-     * the user being edited within the given data source.
+     * Returns whether the current user can change attributes explicitly
+     * associated with the user being edited within the given data source.
      *
      * @param {String} [dataSource]
      *     The identifier of the data source to check. If omitted, this will
@@ -257,6 +257,23 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         // Otherwise, can change attributes if we have permission to update this user
         return PermissionSet.hasUserPermission($scope.permissions[dataSource],
             PermissionSet.ObjectPermissionType.UPDATE, username);
+
+    };
+
+    /**
+     * Returns whether the current user can change/set all user attributes for
+     * the user being edited, regardless of whether those attributes are
+     * already explicitly associated with that user.
+     *
+     * @returns {Boolean}
+     *     true if the current user can change all attributes for the user
+     *     being edited, regardless of whether those attributes are already
+     *     explicitly associated with that user, false otherwise.
+     */
+    $scope.canChangeAllAttributes = function canChangeAllAttributes() {
+
+        // All attributes can be set if we are creating the user
+        return !$scope.userExists(selectedDataSource);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -40,7 +40,8 @@
 
     <!-- Connection attributes section -->
     <div class="attributes">
-        <guac-form namespace="'CONNECTION_ATTRIBUTES'" content="attributes" model="connection.attributes"></guac-form>
+        <guac-form namespace="'CONNECTION_ATTRIBUTES'" content="attributes"
+                   model="connection.attributes" model-only="true"></guac-form>
     </div>
 
     <!-- Connection parameters -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -41,7 +41,7 @@
     <!-- Connection attributes section -->
     <div class="attributes">
         <guac-form namespace="'CONNECTION_ATTRIBUTES'" content="attributes"
-                   model="connection.attributes" model-only="true"></guac-form>
+                   model="connection.attributes" model-only="!canChangeAllAttributes()"></guac-form>
     </div>
 
     <!-- Connection parameters -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -40,7 +40,8 @@
 
     <!-- Connection group attributes section -->
     <div class="attributes">
-        <guac-form namespace="'CONNECTION_GROUP_ATTRIBUTES'" content="attributes" model="connectionGroup.attributes"></guac-form>
+        <guac-form namespace="'CONNECTION_GROUP_ATTRIBUTES'" content="attributes"
+                   model="connectionGroup.attributes" model-only="true"></guac-form>
     </div>
 
     <!-- Form action buttons -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -41,7 +41,7 @@
     <!-- Connection group attributes section -->
     <div class="attributes">
         <guac-form namespace="'CONNECTION_GROUP_ATTRIBUTES'" content="attributes"
-                   model="connectionGroup.attributes" model-only="true"></guac-form>
+                   model="connectionGroup.attributes" model-only="!canChangeAllAttributes()"></guac-form>
     </div>
 
     <!-- Form action buttons -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
@@ -22,7 +22,7 @@
     <!-- Sharing profile attributes section -->
     <div class="attributes">
         <guac-form namespace="'SHARING_PROFILE_ATTRIBUTES'" content="attributes"
-                   model="sharingProfile.attributes" model-only="true"></guac-form>
+                   model="sharingProfile.attributes" model-only="!canChangeAllAttributes()"></guac-form>
     </div>
 
     <!-- Sharing profile parameters -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageSharingProfile.html
@@ -22,7 +22,7 @@
     <!-- Sharing profile attributes section -->
     <div class="attributes">
         <guac-form namespace="'SHARING_PROFILE_ATTRIBUTES'" content="attributes"
-                   model="sharingProfile.attributes"></guac-form>
+                   model="sharingProfile.attributes" model-only="true"></guac-form>
     </div>
 
     <!-- Sharing profile parameters -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -42,7 +42,7 @@
         <!-- User attributes section -->
         <div class="attributes" ng-show="canChangeAttributes()">
             <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
-                       model="user.attributes" model-only="true"></guac-form>
+                       model="user.attributes" model-only="!canChangeAllAttributes()"></guac-form>
         </div>
 
         <!-- System permissions section -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -41,7 +41,8 @@
 
         <!-- User attributes section -->
         <div class="attributes" ng-show="canChangeAttributes()">
-            <guac-form namespace="'USER_ATTRIBUTES'" content="attributes" model="user.attributes"></guac-form>
+            <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
+                       model="user.attributes" model-only="true"></guac-form>
         </div>
 
         <!-- System permissions section -->


### PR DESCRIPTION
Previously, Guacamole users within the database authentication backend could edit any of their own user attributes so long as they had `UPDATE` permission on their own user object. This change modifies this behavior, restricting editing of attributes related to scheduling to users with `ADMINISTER` permission on the user object, and applies that same logic across all object management pages.