### PR TITLE
GUACAMOLE-292: Add base support for user profiles.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -43,6 +43,7 @@ import org.apache.guacamole.auth.jdbc.permission.SharingProfilePermissionService
 import org.apache.guacamole.auth.jdbc.permission.UserPermissionService;
 import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.DateField;
+import org.apache.guacamole.form.EmailField;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.TextField;
@@ -124,7 +125,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      */
     public static final Form PROFILE = new Form("profile", Arrays.<Field>asList(
         new TextField(FULL_NAME_ATTRIBUTE_NAME),
-        new TextField(EMAIL_ADDRESS_ATTRIBUTE_NAME)
+        new EmailField(EMAIL_ADDRESS_ATTRIBUTE_NAME)
     ));
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -45,6 +45,7 @@ import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.DateField;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.Form;
+import org.apache.guacamole.form.TextField;
 import org.apache.guacamole.form.TimeField;
 import org.apache.guacamole.form.TimeZoneField;
 import org.apache.guacamole.net.auth.User;
@@ -63,6 +64,17 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      * Logger for this class.
      */
     private static final Logger logger = LoggerFactory.getLogger(ModeledUser.class);
+
+    /**
+     * The name of the attribute which holds the user's full name, if known.
+     */
+    public static final String FULL_NAME_ATTRIBUTE_NAME = "full-name";
+
+    /**
+     * The name of the attribute which holds the user's email address, if
+     * known.
+     */
+    public static final String EMAIL_ADDRESS_ATTRIBUTE_NAME = "email-address";
 
     /**
      * The name of the attribute which controls whether a user account is
@@ -107,6 +119,15 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     public static final String TIMEZONE_ATTRIBUTE_NAME = "timezone";
 
     /**
+     * All attributes related to user profile information, within a logical
+     * form.
+     */
+    public static final Form PROFILE = new Form("profile", Arrays.<Field>asList(
+        new TextField(FULL_NAME_ATTRIBUTE_NAME),
+        new TextField(EMAIL_ADDRESS_ATTRIBUTE_NAME)
+    ));
+
+    /**
      * All attributes related to restricting user accounts, within a logical
      * form.
      */
@@ -125,6 +146,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      * logical forms.
      */
     public static final Collection<Form> ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(
+        PROFILE,
         ACCOUNT_RESTRICTIONS
     ));
 
@@ -372,6 +394,25 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     }
 
     /**
+     * Stores all unrestricted (unprivileged) attributes within the given Map,
+     * pulling the values of those attributes from the underlying user model.
+     * If no value is yet defined for an attribute, that attribute will be set
+     * to null.
+     *
+     * @param attributes
+     *     The Map to store all unrestricted attributes within.
+     */
+    private void putUnrestrictedAttributes(Map<String, String> attributes) {
+
+        // Set full name attribute
+        attributes.put(FULL_NAME_ATTRIBUTE_NAME, "Testy McTesterson"); // TODO
+
+        // Set email address attribute
+        attributes.put(EMAIL_ADDRESS_ATTRIBUTE_NAME, "test@test.test"); // TODO
+
+    }
+
+    /**
      * Parses the given string into a corresponding date. The string must
      * follow the standard format used by date attributes, as defined by
      * DateField.FORMAT and as would be produced by DateField.format().
@@ -477,10 +518,30 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
 
     }
 
+    /**
+     * Stores all unrestricted (unprivileged) attributes within the underlying
+     * user model, pulling the values of those attributes from the given Map.
+     *
+     * @param attributes
+     *     The Map to pull all unrestricted attributes from.
+     */
+    private void setUnrestrictedAttributes(Map<String, String> attributes) {
+
+        // Translate full name attribute
+        logger.info("FULL NAME: \"{}\"", attributes.get(FULL_NAME_ATTRIBUTE_NAME)); // TODO
+
+        // Translate email address attribute
+        logger.info("EMAIL ADDRESS: \"{}\"", attributes.get(EMAIL_ADDRESS_ATTRIBUTE_NAME)); // TODO
+
+    }
+
     @Override
     public Map<String, String> getAttributes() {
 
         Map<String, String> attributes = new HashMap<String, String>();
+
+        // Always include unrestricted attributes
+        putUnrestrictedAttributes(attributes);
 
         // Include restricted attributes only if they should be exposed
         if (exposeRestrictedAttributes)
@@ -491,6 +552,9 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
 
     @Override
     public void setAttributes(Map<String, String> attributes) {
+
+        // Always assign unrestricted attributes
+        setUnrestrictedAttributes(attributes);
 
         // Assign restricted attributes only if they are exposed
         if (exposeRestrictedAttributes)

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -114,7 +114,9 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      */
     public static final Form PROFILE = new Form("profile", Arrays.<Field>asList(
         new TextField(User.Attribute.FULL_NAME),
-        new EmailField(User.Attribute.EMAIL_ADDRESS)
+        new EmailField(User.Attribute.EMAIL_ADDRESS),
+        new TextField(User.Attribute.ORGANIZATION),
+        new TextField(User.Attribute.ORGANIZATIONAL_ROLE)
     ));
 
     /**
@@ -400,6 +402,12 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
         // Set email address attribute
         attributes.put(User.Attribute.EMAIL_ADDRESS, "test@test.test"); // TODO
 
+        // Set organization attribute
+        attributes.put(User.Attribute.ORGANIZATION, "Example, Inc."); // TODO
+
+        // Set role attribute
+        attributes.put(User.Attribute.ORGANIZATIONAL_ROLE, "Senior Lead Architect"); // TODO
+
     }
 
     /**
@@ -522,6 +530,12 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
 
         // Translate email address attribute
         logger.info("EMAIL ADDRESS: \"{}\"", attributes.get(User.Attribute.EMAIL_ADDRESS)); // TODO
+
+        // Translate organization attribute
+        logger.info("ORGANIZATION: \"{}\"", attributes.get(User.Attribute.ORGANIZATION)); // TODO
+
+        // Translate role attribute
+        logger.info("ORGANIZATIONAL ROLE: \"{}\"", attributes.get(User.Attribute.ORGANIZATIONAL_ROLE)); // TODO
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -397,16 +397,16 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     private void putUnrestrictedAttributes(Map<String, String> attributes) {
 
         // Set full name attribute
-        attributes.put(User.Attribute.FULL_NAME, "Testy McTesterson"); // TODO
+        attributes.put(User.Attribute.FULL_NAME, getModel().getFullName());
 
         // Set email address attribute
-        attributes.put(User.Attribute.EMAIL_ADDRESS, "test@test.test"); // TODO
+        attributes.put(User.Attribute.EMAIL_ADDRESS, getModel().getEmailAddress());
 
         // Set organization attribute
-        attributes.put(User.Attribute.ORGANIZATION, "Example, Inc."); // TODO
+        attributes.put(User.Attribute.ORGANIZATION, getModel().getOrganization());
 
         // Set role attribute
-        attributes.put(User.Attribute.ORGANIZATIONAL_ROLE, "Senior Lead Architect"); // TODO
+        attributes.put(User.Attribute.ORGANIZATIONAL_ROLE, getModel().getOrganizationalRole());
 
     }
 
@@ -526,16 +526,16 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     private void setUnrestrictedAttributes(Map<String, String> attributes) {
 
         // Translate full name attribute
-        logger.info("FULL NAME: \"{}\"", attributes.get(User.Attribute.FULL_NAME)); // TODO
+        getModel().setFullName(attributes.get(User.Attribute.FULL_NAME));
 
         // Translate email address attribute
-        logger.info("EMAIL ADDRESS: \"{}\"", attributes.get(User.Attribute.EMAIL_ADDRESS)); // TODO
+        getModel().setEmailAddress(attributes.get(User.Attribute.EMAIL_ADDRESS));
 
         // Translate organization attribute
-        logger.info("ORGANIZATION: \"{}\"", attributes.get(User.Attribute.ORGANIZATION)); // TODO
+        getModel().setOrganization(attributes.get(User.Attribute.ORGANIZATION));
 
         // Translate role attribute
-        logger.info("ORGANIZATIONAL ROLE: \"{}\"", attributes.get(User.Attribute.ORGANIZATIONAL_ROLE)); // TODO
+        getModel().setOrganizationalRole(attributes.get(User.Attribute.ORGANIZATIONAL_ROLE));
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -67,17 +67,6 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     private static final Logger logger = LoggerFactory.getLogger(ModeledUser.class);
 
     /**
-     * The name of the attribute which holds the user's full name, if known.
-     */
-    public static final String FULL_NAME_ATTRIBUTE_NAME = "full-name";
-
-    /**
-     * The name of the attribute which holds the user's email address, if
-     * known.
-     */
-    public static final String EMAIL_ADDRESS_ATTRIBUTE_NAME = "email-address";
-
-    /**
      * The name of the attribute which controls whether a user account is
      * disabled.
      */
@@ -124,8 +113,8 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      * form.
      */
     public static final Form PROFILE = new Form("profile", Arrays.<Field>asList(
-        new TextField(FULL_NAME_ATTRIBUTE_NAME),
-        new EmailField(EMAIL_ADDRESS_ATTRIBUTE_NAME)
+        new TextField(User.Attribute.FULL_NAME),
+        new EmailField(User.Attribute.EMAIL_ADDRESS)
     ));
 
     /**
@@ -406,10 +395,10 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     private void putUnrestrictedAttributes(Map<String, String> attributes) {
 
         // Set full name attribute
-        attributes.put(FULL_NAME_ATTRIBUTE_NAME, "Testy McTesterson"); // TODO
+        attributes.put(User.Attribute.FULL_NAME, "Testy McTesterson"); // TODO
 
         // Set email address attribute
-        attributes.put(EMAIL_ADDRESS_ATTRIBUTE_NAME, "test@test.test"); // TODO
+        attributes.put(User.Attribute.EMAIL_ADDRESS, "test@test.test"); // TODO
 
     }
 
@@ -529,10 +518,10 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     private void setUnrestrictedAttributes(Map<String, String> attributes) {
 
         // Translate full name attribute
-        logger.info("FULL NAME: \"{}\"", attributes.get(FULL_NAME_ATTRIBUTE_NAME)); // TODO
+        logger.info("FULL NAME: \"{}\"", attributes.get(User.Attribute.FULL_NAME)); // TODO
 
         // Translate email address attribute
-        logger.info("EMAIL ADDRESS: \"{}\"", attributes.get(EMAIL_ADDRESS_ATTRIBUTE_NAME)); // TODO
+        logger.info("EMAIL ADDRESS: \"{}\"", attributes.get(User.Attribute.EMAIL_ADDRESS)); // TODO
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserModel.java
@@ -93,6 +93,28 @@ public class UserModel extends ObjectModel {
     private String timeZone;
 
     /**
+     * The user's full name, or null if this is not known.
+     */
+    private String fullName;
+
+    /**
+     * The email address of the user, or null if this is not known.
+     */
+    private String emailAddress;
+
+    /**
+     * The organization, company, group, etc. that the user belongs to, or null
+     * if this is not known.
+     */
+    private String organization;
+
+    /**
+     * The role that the user has at the organization, company, group, etc.
+     * they belong to, or null if this is not known.
+     */
+    private String organizationalRole;
+
+    /**
      * Creates a new, empty user.
      */
     public UserModel() {
@@ -349,6 +371,95 @@ public class UserModel extends ObjectModel {
      */
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
+    }
+
+    /**
+     * Returns the user's full name, if known. If not available, null is
+     * returned.
+     *
+     * @return
+     *     The user's full name, or null if this is not known.
+     */
+    public String getFullName() {
+        return fullName;
+    }
+
+    /**
+     * Sets the user's full name.
+     *
+     * @param fullName
+     *     The user's full name, or null if this is not known.
+     */
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    /**
+     * Returns the email address of the user, if known. If not available, null
+     * is returned.
+     *
+     * @return
+     *     The email address of the user, or null if this is not known.
+     */
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    /**
+     * Sets the email address of the user.
+     *
+     * @param emailAddress
+     *     The email address of the user, or null if this is not known.
+     */
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    /**
+     * Returns the organization, company, group, etc. that the user belongs to,
+     * if known. If not available, null is returned.
+     *
+     * @return
+     *     The organization, company, group, etc. that the user belongs to, or
+     *     null if this is not known.
+     */
+    public String getOrganization() {
+        return organization;
+    }
+
+    /**
+     * Sets the organization, company, group, etc. that the user belongs to.
+     *
+     * @param organization
+     *     The organization, company, group, etc. that the user belongs to, or
+     *     null if this is not known.
+     */
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    /**
+     * Returns the role that the user has at the organization, company, group,
+     * etc. they belong to. If not available, null is returned.
+     *
+     * @return
+     *     The role that the user has at the organization, company, group, etc.
+     *     they belong to, or null if this is not known.
+     */
+    public String getOrganizationalRole() {
+        return organizationalRole;
+    }
+
+    /**
+     * Sets the role that the user has at the organization, company, group,
+     * etc. they belong to.
+     *
+     * @param organizationalRole
+     *     The role that the user has at the organization, company, group, etc.
+     *     they belong to, or null if this is not known.
+     */
+    public void setOrganizationalRole(String organizationalRole) {
+        this.organizationalRole = organizationalRole;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -79,13 +79,16 @@
 
         "FIELD_HEADER_DISABLED"            : "Login disabled:",
         "FIELD_HEADER_EXPIRED"             : "Password expired:",
+        "FIELD_HEADER_EMAIL_ADDRESS"       : "Email address:",
+        "FIELD_HEADER_FULL_NAME"           : "Full name:",
         "FIELD_HEADER_ACCESS_WINDOW_END"   : "Do not allow access after:",
         "FIELD_HEADER_ACCESS_WINDOW_START" : "Allow access after:",
         "FIELD_HEADER_TIMEZONE"            : "User time zone:",
         "FIELD_HEADER_VALID_FROM"          : "Enable account after:",
         "FIELD_HEADER_VALID_UNTIL"         : "Disable account after:",
 
-        "SECTION_HEADER_RESTRICTIONS" : "Account Restrictions"
+        "SECTION_HEADER_RESTRICTIONS" : "Account Restrictions",
+        "SECTION_HEADER_PROFILE"      : "Profile"
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -79,8 +79,6 @@
 
         "FIELD_HEADER_DISABLED"            : "Login disabled:",
         "FIELD_HEADER_EXPIRED"             : "Password expired:",
-        "FIELD_HEADER_EMAIL_ADDRESS"       : "Email address:",
-        "FIELD_HEADER_FULL_NAME"           : "Full name:",
         "FIELD_HEADER_ACCESS_WINDOW_END"   : "Do not allow access after:",
         "FIELD_HEADER_ACCESS_WINDOW_START" : "Allow access after:",
         "FIELD_HEADER_TIMEZONE"            : "User time zone:",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -102,6 +102,12 @@ CREATE TABLE `guacamole_user` (
   -- Timezone used for all date/time comparisons and interpretation
   `timezone` VARCHAR(64),
 
+  -- Profile information
+  `full_name`           VARCHAR(256),
+  `email_address`       VARCHAR(256),
+  `organization`        VARCHAR(256),
+  `organizational_role` VARCHAR(256),
+
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`)
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.13.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.13.sql
@@ -28,3 +28,13 @@ ALTER TABLE guacamole_connection ADD COLUMN proxy_encryption_method ENUM(
     'NONE',
     'SSL'
 );
+
+--
+-- Add new user profile columns
+--
+
+ALTER TABLE guacamole_user ADD COLUMN full_name           VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN email_address       VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN organization        VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN organizational_role VARCHAR(256);
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
@@ -25,17 +25,21 @@
 
     <!-- Result mapper for user objects -->
     <resultMap id="UserResultMap" type="org.apache.guacamole.auth.jdbc.user.UserModel" >
-        <id     column="user_id"             property="objectID"          jdbcType="INTEGER"/>
-        <result column="username"            property="identifier"        jdbcType="VARCHAR"/>
-        <result column="password_hash"       property="passwordHash"      jdbcType="BINARY"/>
-        <result column="password_salt"       property="passwordSalt"      jdbcType="BINARY"/>
-        <result column="password_date"       property="passwordDate"      jdbcType="TIMESTAMP"/>
-        <result column="disabled"            property="disabled"          jdbcType="BOOLEAN"/>
-        <result column="access_window_start" property="accessWindowStart" jdbcType="TIME"/>
-        <result column="access_window_end"   property="accessWindowEnd"   jdbcType="TIME"/>
-        <result column="valid_from"          property="validFrom"         jdbcType="DATE"/>
-        <result column="valid_until"         property="validUntil"        jdbcType="DATE"/>
-        <result column="timezone"            property="timeZone"          jdbcType="VARCHAR"/>
+        <id     column="user_id"             property="objectID"           jdbcType="INTEGER"/>
+        <result column="username"            property="identifier"         jdbcType="VARCHAR"/>
+        <result column="password_hash"       property="passwordHash"       jdbcType="BINARY"/>
+        <result column="password_salt"       property="passwordSalt"       jdbcType="BINARY"/>
+        <result column="password_date"       property="passwordDate"       jdbcType="TIMESTAMP"/>
+        <result column="disabled"            property="disabled"           jdbcType="BOOLEAN"/>
+        <result column="access_window_start" property="accessWindowStart"  jdbcType="TIME"/>
+        <result column="access_window_end"   property="accessWindowEnd"    jdbcType="TIME"/>
+        <result column="valid_from"          property="validFrom"          jdbcType="DATE"/>
+        <result column="valid_until"         property="validUntil"         jdbcType="DATE"/>
+        <result column="timezone"            property="timeZone"           jdbcType="VARCHAR"/>
+        <result column="full_name"           property="fullName"           jdbcType="VARCHAR"/>
+        <result column="email_address"       property="emailAddress"       jdbcType="VARCHAR"/>
+        <result column="organization"        property="organization"       jdbcType="VARCHAR"/>
+        <result column="organizational_role" property="organizationalRole" jdbcType="VARCHAR"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -69,7 +73,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -94,7 +102,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -122,7 +134,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -150,7 +166,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
@@ -163,7 +183,11 @@
             #{object.accessWindowEnd,jdbcType=TIME},
             #{object.validFrom,jdbcType=DATE},
             #{object.validUntil,jdbcType=DATE},
-            #{object.timeZone,jdbcType=VARCHAR}
+            #{object.timeZone,jdbcType=VARCHAR},
+            #{object.fullName,jdbcType=VARCHAR},
+            #{object.emailAddress,jdbcType=VARCHAR},
+            #{object.organization,jdbcType=VARCHAR},
+            #{object.organizationalRole,jdbcType=VARCHAR}
         )
 
     </insert>
@@ -180,7 +204,11 @@
             access_window_end = #{object.accessWindowEnd,jdbcType=TIME},
             valid_from = #{object.validFrom,jdbcType=DATE},
             valid_until = #{object.validUntil,jdbcType=DATE},
-            timezone = #{object.timeZone,jdbcType=VARCHAR}
+            timezone = #{object.timeZone,jdbcType=VARCHAR},
+            full_name = #{object.fullName,jdbcType=VARCHAR},
+            email_address = #{object.emailAddress,jdbcType=VARCHAR},
+            organization = #{object.organization,jdbcType=VARCHAR},
+            organizational_role = #{object.organizationalRole,jdbcType=VARCHAR}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -143,6 +143,12 @@ CREATE TABLE guacamole_user (
   -- Timezone used for all date/time comparisons and interpretation
   timezone varchar(64),
 
+  -- Profile information
+  full_name           varchar(256),
+  email_address       varchar(256),
+  organization        varchar(256),
+  organizational_role varchar(256),
+
   PRIMARY KEY (user_id),
 
   CONSTRAINT username

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.13.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.13.sql
@@ -33,3 +33,13 @@ CREATE TYPE guacamole_proxy_encryption_method AS ENUM(
 ALTER TABLE guacamole_connection ADD COLUMN proxy_port integer;
 ALTER TABLE guacamole_connection ADD COLUMN proxy_hostname varchar(512);
 ALTER TABLE guacamole_connection ADD COLUMN proxy_encryption_method guacamole_proxy_encryption_method;
+
+--
+-- Add new user profile columns
+--
+
+ALTER TABLE guacamole_user ADD COLUMN full_name           VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN email_address       VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN organization        VARCHAR(256);
+ALTER TABLE guacamole_user ADD COLUMN organizational_role VARCHAR(256);
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
@@ -25,18 +25,22 @@
 
     <!-- Result mapper for user objects -->
     <resultMap id="UserResultMap" type="org.apache.guacamole.auth.jdbc.user.UserModel" >
-        <id     column="user_id"             property="objectID"          jdbcType="INTEGER"/>
-        <result column="username"            property="identifier"        jdbcType="VARCHAR"/>
-        <result column="password_hash"       property="passwordHash"      jdbcType="BINARY"/>
-        <result column="password_salt"       property="passwordSalt"      jdbcType="BINARY"/>
-        <result column="password_date"       property="passwordDate"      jdbcType="TIMESTAMP"/>
-        <result column="disabled"            property="disabled"          jdbcType="BOOLEAN"/>
-        <result column="expired"             property="expired"           jdbcType="BOOLEAN"/>
-        <result column="access_window_start" property="accessWindowStart" jdbcType="TIME"/>
-        <result column="access_window_end"   property="accessWindowEnd"   jdbcType="TIME"/>
-        <result column="valid_from"          property="validFrom"         jdbcType="DATE"/>
-        <result column="valid_until"         property="validUntil"        jdbcType="DATE"/>
-        <result column="timezone"            property="timeZone"          jdbcType="VARCHAR"/>
+        <id     column="user_id"             property="objectID"           jdbcType="INTEGER"/>
+        <result column="username"            property="identifier"         jdbcType="VARCHAR"/>
+        <result column="password_hash"       property="passwordHash"       jdbcType="BINARY"/>
+        <result column="password_salt"       property="passwordSalt"       jdbcType="BINARY"/>
+        <result column="password_date"       property="passwordDate"       jdbcType="TIMESTAMP"/>
+        <result column="disabled"            property="disabled"           jdbcType="BOOLEAN"/>
+        <result column="expired"             property="expired"            jdbcType="BOOLEAN"/>
+        <result column="access_window_start" property="accessWindowStart"  jdbcType="TIME"/>
+        <result column="access_window_end"   property="accessWindowEnd"    jdbcType="TIME"/>
+        <result column="valid_from"          property="validFrom"          jdbcType="DATE"/>
+        <result column="valid_until"         property="validUntil"         jdbcType="DATE"/>
+        <result column="timezone"            property="timeZone"           jdbcType="VARCHAR"/>
+        <result column="full_name"           property="fullName"           jdbcType="VARCHAR"/>
+        <result column="email_address"       property="emailAddress"       jdbcType="VARCHAR"/>
+        <result column="organization"        property="organization"       jdbcType="VARCHAR"/>
+        <result column="organizational_role" property="organizationalRole" jdbcType="VARCHAR"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -70,7 +74,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -95,7 +103,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -123,7 +135,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -151,7 +167,11 @@
             access_window_end,
             valid_from,
             valid_until,
-            timezone
+            timezone,
+            full_name,
+            email_address,
+            organization,
+            organizational_role
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
@@ -164,7 +184,11 @@
             #{object.accessWindowEnd,jdbcType=TIME},
             #{object.validFrom,jdbcType=DATE},
             #{object.validUntil,jdbcType=DATE},
-            #{object.timeZone,jdbcType=VARCHAR}
+            #{object.timeZone,jdbcType=VARCHAR},
+            #{object.fullName,jdbcType=VARCHAR},
+            #{object.emailAddress,jdbcType=VARCHAR},
+            #{object.organization,jdbcType=VARCHAR},
+            #{object.organizationalRole,jdbcType=VARCHAR}
         )
 
     </insert>
@@ -181,7 +205,11 @@
             access_window_end = #{object.accessWindowEnd,jdbcType=TIME},
             valid_from = #{object.validFrom,jdbcType=DATE},
             valid_until = #{object.validUntil,jdbcType=DATE},
-            timezone = #{object.timeZone,jdbcType=VARCHAR}
+            timezone = #{object.timeZone,jdbcType=VARCHAR},
+            full_name = #{object.fullName,jdbcType=VARCHAR},
+            email_address = #{object.emailAddress,jdbcType=VARCHAR},
+            organization = #{object.organization,jdbcType=VARCHAR},
+            organizational_role = #{object.organizationalRole,jdbcType=VARCHAR}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/form/EmailField.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/form/EmailField.java
@@ -17,29 +17,21 @@
  * under the License.
  */
 
-input[type=checkbox], input[type=number], input[type=text], input[type=email], input[type=radio], label, textarea {
-    -webkit-tap-highlight-color: rgba(128,192,128,0.5);
-}
+package org.apache.guacamole.form;
 
-div.location, input[type=text], input[type=email], input[type=number], input[type=password], textarea {
-    border: 1px solid #777;
-    -moz-border-radius: 0.2em;
-    -webkit-border-radius: 0.2em;
-    -khtml-border-radius: 0.2em;
-    border-radius: 0.2em;
-    width: 100%;
-    max-width: 16em;
-    padding: 0.25em;
-    font-size: 0.8em;
-    background: white;
-    cursor: text;
-}
+/**
+ * Represents a text field which may contain an email address.
+ */
+public class EmailField extends Field {
 
-textarea {
-    max-width: none;
-    width: 30em;
-    height: 10em;
-    white-space: pre;
-    word-wrap: normal;
-    overflow: auto;
+    /**
+     * Creates a new EmailField with the given name.
+     *
+     * @param name
+     *     The unique name to associate with this field.
+     */
+    public EmailField(String name) {
+        super(name, Field.Type.EMAIL);
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/form/Field.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/form/Field.java
@@ -48,6 +48,12 @@ public class Field {
         public static String TEXT = "TEXT";
 
         /**
+         * An email address field. This field type generally behaves
+         * identically to arbitrary text fields, but has semantic differences.
+         */
+        public static String EMAIL = "EMAIL";
+
+        /**
          * A username field. This field type generally behaves identically to
          * arbitrary text fields, but has semantic differences.
          */

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
@@ -49,6 +49,17 @@ public interface User extends Identifiable {
          */
         public static String EMAIL_ADDRESS = "guac-email-address";
 
+        /**
+         * The organization, company, group, etc. that the user belongs to.
+         */
+        public static String ORGANIZATION = "guac-organization";
+
+        /**
+         * The role that the user has at the organization, company, group, etc.
+         * they belong to.
+         */
+        public static String ORGANIZATIONAL_ROLE = "guac-organizational-role";
+
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
@@ -31,6 +31,27 @@ import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 public interface User extends Identifiable {
 
     /**
+     * All standard attribute names with semantics defined by the Guacamole web
+     * application. Extensions may additionally define their own attributes
+     * with completely arbitrary names and semantics, so long as those names do
+     * not conflict with the names listed here. All standard attribute names
+     * have a "guac-" prefix to avoid such conflicts.
+     */
+    public static class Attribute {
+
+        /**
+         * The user's full name.
+         */
+        public static String FULL_NAME = "guac-full-name";
+
+        /**
+         * The email address of the user.
+         */
+        public static String EMAIL_ADDRESS = "guac-email-address";
+
+    }
+
+    /**
      * Returns this user's password. Note that the password returned may be
      * hashed or completely arbitrary.
      *

--- a/guacamole/src/main/webapp/app/form/directives/form.js
+++ b/guacamole/src/main/webapp/app/form/directives/form.js
@@ -64,7 +64,16 @@ angular.module('form').directive('guacForm', [function form() {
              *
              * @type Boolean
              */
-            modelOnly : '='
+            modelOnly : '=',
+
+            /**
+             * Whether the contents of the form should be restricted to those
+             * fields/forms which have associated values defined within the
+             * given model object. By default, all fields will be shown.
+             *
+             * @type Boolean
+             */
+            valuesOnly : '='
 
         },
         templateUrl: 'app/form/templates/form.html',
@@ -184,14 +193,18 @@ angular.module('form').directive('guacForm', [function form() {
              */
             $scope.isVisible = function isVisible(field) {
 
-                // All fields are visible if contents are not restricted to
-                // model properties only
-                if (!$scope.modelOnly)
-                    return true;
+                // Forms with valuesOnly set should display only fields with
+                // associated values in the model object
+                if ($scope.valuesOnly)
+                    return field && $scope.values[field.name];
 
-                // Otherwise, fields are only visible if they are present
-                // within the model
-                return field && (field.name in $scope.values);
+                // Forms with modelOnly set should display only fields with
+                // associated properties in the model object
+                if ($scope.modelOnly)
+                    return field && (field.name in $scope.values);
+
+                // Otherwise, all fields are visible
+                return true;
 
             };
 

--- a/guacamole/src/main/webapp/app/form/directives/form.js
+++ b/guacamole/src/main/webapp/app/form/directives/form.js
@@ -64,16 +64,7 @@ angular.module('form').directive('guacForm', [function form() {
              *
              * @type Boolean
              */
-            modelOnly : '=',
-
-            /**
-             * Whether the contents of the form should be restricted to those
-             * fields/forms which have associated values defined within the
-             * given model object. By default, all fields will be shown.
-             *
-             * @type Boolean
-             */
-            valuesOnly : '='
+            modelOnly : '='
 
         },
         templateUrl: 'app/form/templates/form.html',
@@ -193,18 +184,14 @@ angular.module('form').directive('guacForm', [function form() {
              */
             $scope.isVisible = function isVisible(field) {
 
-                // Forms with valuesOnly set should display only fields with
-                // associated values in the model object
-                if ($scope.valuesOnly)
-                    return field && $scope.values[field.name];
+                // All fields are visible if contents are not restricted to
+                // model properties only
+                if (!$scope.modelOnly)
+                    return true;
 
-                // Forms with modelOnly set should display only fields with
-                // associated properties in the model object
-                if ($scope.modelOnly)
-                    return field && (field.name in $scope.values);
-
-                // Otherwise, all fields are visible
-                return true;
+                // Otherwise, fields are only visible if they are present
+                // within the model
+                return field && (field.name in $scope.values);
 
             };
 

--- a/guacamole/src/main/webapp/app/form/services/formService.js
+++ b/guacamole/src/main/webapp/app/form/services/formService.js
@@ -48,6 +48,16 @@ angular.module('form').provider('formService', function formServiceProvider() {
         },
 
         /**
+         * Email address field type.
+         *
+         * @see {@link Field.Type.EMAIL}
+         * @type FieldType
+         */
+        'EMAIL' : {
+            templateUrl : 'app/form/templates/emailField.html'
+        },
+
+        /**
          * Numeric field type.
          *
          * @see {@link Field.Type.NUMERIC}

--- a/guacamole/src/main/webapp/app/form/templates/emailField.html
+++ b/guacamole/src/main/webapp/app/form/templates/emailField.html
@@ -1,0 +1,8 @@
+<div class="email-field">
+    <input type="email"
+           ng-model="model"
+           ng-hide="readOnly"
+           autocorrect="off"
+           autocapitalize="off"/>
+    <a href="mailto:{{model}}" ng-show="readOnly">{{model}}</a>
+</div>

--- a/guacamole/src/main/webapp/app/manage/styles/attributes.css
+++ b/guacamole/src/main/webapp/app/manage/styles/attributes.css
@@ -19,6 +19,7 @@
 
 /* Do not stretch attributes to fit available area */
 .attributes input[type=text],
+.attributes input[type=email],
 .attributes input[type=password],
 .attributes input[type=number] {
     width: auto;

--- a/guacamole/src/main/webapp/app/manage/styles/connection-parameter.css
+++ b/guacamole/src/main/webapp/app/manage/styles/connection-parameter.css
@@ -19,6 +19,7 @@
 
 /* Do not stretch connection parameters to fit available area */
 .connection-parameters input[type=text],
+.connection-parameters input[type=email],
 .connection-parameters input[type=password],
 .connection-parameters input[type=number] {
     width: auto;

--- a/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
@@ -47,6 +47,8 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
             var $location             = $injector.get('$location');
             var $route                = $injector.get('$route');
             var authenticationService = $injector.get('authenticationService');
+            var schemaService         = $injector.get('schemaService');
+            var userService           = $injector.get('userService');
             var userPageService       = $injector.get('userPageService');
 
             /**
@@ -56,6 +58,18 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
              */
             $scope.username = authenticationService.getCurrentUsername();
             
+            // Pull user attribute schema
+            schemaService.getUserAttributes(authenticationService.getDataSource())
+                    .success(function attributesReceived(attributes) {
+                $scope.attributes = attributes;
+            });
+
+            // Pull user data
+            userService.getUser(authenticationService.getDataSource(), $scope.username)
+                    .success(function userRetrieved(user) {
+                $scope.user = user;
+            });
+
             /**
              * The available main pages for the current user.
              * 

--- a/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
@@ -43,11 +43,13 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
         controller: ['$scope', '$injector',
             function guacUserMenuController($scope, $injector) {
 
+            // Required types
+            var User = $injector.get('User');
+
             // Get required services
             var $location             = $injector.get('$location');
             var $route                = $injector.get('$route');
             var authenticationService = $injector.get('authenticationService');
-            var schemaService         = $injector.get('schemaService');
             var userService           = $injector.get('userService');
             var userPageService       = $injector.get('userPageService');
 
@@ -57,17 +59,57 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
              * @type String
              */
             $scope.username = authenticationService.getCurrentUsername();
-            
-            // Pull user attribute schema
-            schemaService.getUserAttributes(authenticationService.getDataSource())
-                    .success(function attributesReceived(attributes) {
-                $scope.attributes = attributes;
-            });
+
+            /**
+             * The user's full name. If not yet available, or if not defined,
+             * this will be null.
+             *
+             * @type String
+             */
+            $scope.fullName = null;
+
+            /**
+             * A URL pointing to relevant user information such as the user's
+             * email address. If not yet available, or if no such URL can be
+             * determined, this will be null.
+             *
+             * @type String
+             */
+            $scope.userURL = null;
+
+            /**
+             * The organization, company, group, etc. that the user belongs to.
+             * If not yet available, or if not defined, this will be null.
+             *
+             * @type String
+             */
+            $scope.organization = null;
+
+            /**
+             * The role that the user has at the organization, company, group,
+             * etc. they belong to. If not yet available, or if not defined,
+             * this will be null.
+             *
+             * @type String
+             */
+            $scope.role = null;
 
             // Pull user data
             userService.getUser(authenticationService.getDataSource(), $scope.username)
                     .success(function userRetrieved(user) {
+
+                // Store retrieved user object
                 $scope.user = user;
+
+                // Pull basic profile information
+                $scope.fullName = user.attributes[User.Attributes.FULL_NAME];
+                $scope.organization = user.attributes[User.Attributes.ORGANIZATION];
+                $scope.role = user.attributes[User.Attributes.ORGANIZATIONAL_ROLE];
+
+                // Link to email address if available
+                var email = user.attributes[User.Attributes.EMAIL_ADDRESS];
+                $scope.userURL = email ? 'mailto:' + email : null;
+
             });
 
             /**

--- a/guacamole/src/main/webapp/app/navigation/navigationModule.js
+++ b/guacamole/src/main/webapp/app/navigation/navigationModule.js
@@ -22,6 +22,7 @@
  */
 angular.module('navigation', [
     'auth',
+    'form',
     'notification',
     'rest'
 ]);

--- a/guacamole/src/main/webapp/app/navigation/styles/user-menu.css
+++ b/guacamole/src/main/webapp/app/navigation/styles/user-menu.css
@@ -82,3 +82,15 @@
 .user-menu .menu-dropdown .menu-contents li a.logout {
     background-image: url('images/action-icons/guac-logout-dark.png');
 }
+
+.user-menu .menu-dropdown .menu-contents .profile {
+    margin: 1em;
+    padding-bottom: 1em;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    width: 2in;
+}
+
+.user-menu .menu-dropdown .menu-contents .profile span.field-header,
+.user-menu .menu-dropdown .menu-contents .profile h3 {
+    display: none;
+}

--- a/guacamole/src/main/webapp/app/navigation/styles/user-menu.css
+++ b/guacamole/src/main/webapp/app/navigation/styles/user-menu.css
@@ -90,7 +90,10 @@
     width: 2in;
 }
 
-.user-menu .menu-dropdown .menu-contents .profile span.field-header,
-.user-menu .menu-dropdown .menu-contents .profile h3 {
-    display: none;
+.user-menu .menu-dropdown .menu-contents .profile .full-name {
+    font-weight: bold;
+}
+.user-menu .menu-dropdown .menu-contents .profile .organization,
+.user-menu .menu-dropdown .menu-contents .profile .organizational-role {
+    font-size: 0.8em;
 }

--- a/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
+++ b/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
@@ -2,10 +2,10 @@
     <guac-menu menu-title="username">
            
         <!-- User profile view -->
-        <div class="profile">
-            <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
-                       model="user.attributes" values-only="true"
-                       read-only="true"></guac-form>
+        <div class="profile" ng-show="fullName">
+            <div class="full-name"><a ng-href="{{userURL}}">{{ fullName }}</a></div>
+            <div class="organizational-role" ng-show="role">{{ role }}</div>
+            <div class="organization" ng-show="organization">{{ organization }}</div>
         </div>
 
         <!-- Local actions -->

--- a/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
+++ b/guacamole/src/main/webapp/app/navigation/templates/guacUserMenu.html
@@ -1,6 +1,13 @@
 <div class="user-menu" ng-show="!isAnonymous()">
     <guac-menu menu-title="username">
            
+        <!-- User profile view -->
+        <div class="profile">
+            <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
+                       model="user.attributes" values-only="true"
+                       read-only="true"></guac-form>
+        </div>
+
         <!-- Local actions -->
         <ul class="action-list">
             <li ng-repeat="action in localActions">

--- a/guacamole/src/main/webapp/app/rest/types/Field.js
+++ b/guacamole/src/main/webapp/app/rest/types/Field.js
@@ -76,6 +76,14 @@ angular.module('rest').factory('Field', [function defineField() {
         TEXT : 'TEXT',
 
         /**
+         * The type string associated with parameters that may contain an email
+         * address.
+         *
+         * @type String
+         */
+        EMAIL : 'EMAIL',
+
+        /**
          * The type string associated with parameters that may contain an
          * arbitrary string, where that string represents the username of the
          * user authenticating with the remote desktop service.

--- a/guacamole/src/main/webapp/app/rest/types/User.js
+++ b/guacamole/src/main/webapp/app/rest/types/User.js
@@ -64,6 +64,31 @@ angular.module('rest').factory('User', [function defineUser() {
 
     };
 
+    /**
+     * All standard attribute names with semantics defined by the Guacamole web
+     * application. Extensions may additionally define their own attributes
+     * with completely arbitrary names and semantics, so long as those names do
+     * not conflict with the names listed here. All standard attribute names
+     * have a "guac-" prefix to avoid such conflicts.
+     */
+    User.Attributes = {
+
+        /**
+         * The user's full name.
+         *
+         * @type String
+         */
+        FULL_NAME : 'guac-full-name',
+
+        /**
+         * The email address of the user.
+         *
+         * @type String
+         */
+        EMAIL_ADDRESS : 'guac-email-address'
+
+    };
+
     return User;
 
 }]);

--- a/guacamole/src/main/webapp/app/rest/types/User.js
+++ b/guacamole/src/main/webapp/app/rest/types/User.js
@@ -85,7 +85,22 @@ angular.module('rest').factory('User', [function defineUser() {
          *
          * @type String
          */
-        EMAIL_ADDRESS : 'guac-email-address'
+        EMAIL_ADDRESS : 'guac-email-address',
+
+        /**
+         * The organization, company, group, etc. that the user belongs to.
+         *
+         * @type String
+         */
+        ORGANIZATION : 'guac-organization',
+
+        /**
+         * The role that the user has at the organization, company, group, etc.
+         * they belong to.
+         *
+         * @type String
+         */
+        ORGANIZATIONAL_ROLE : 'guac-organizational-role'
 
     };
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -697,6 +697,13 @@
 
     },
 
+    "USER_ATTRIBUTES" : {
+
+        "FIELD_HEADER_GUAC_EMAIL_ADDRESS" : "Email address:",
+        "FIELD_HEADER_GUAC_FULL_NAME"     : "Full name:"
+
+    },
+
     "USER_MENU" : {
 
         "ACTION_LOGOUT"             : "@:APP.ACTION_LOGOUT",

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -699,8 +699,10 @@
 
     "USER_ATTRIBUTES" : {
 
-        "FIELD_HEADER_GUAC_EMAIL_ADDRESS" : "Email address:",
-        "FIELD_HEADER_GUAC_FULL_NAME"     : "Full name:"
+        "FIELD_HEADER_GUAC_EMAIL_ADDRESS"       : "Email address:",
+        "FIELD_HEADER_GUAC_FULL_NAME"           : "Full name:",
+        "FIELD_HEADER_GUAC_ORGANIZATION"        : "Organization:",
+        "FIELD_HEADER_GUAC_ORGANIZATIONAL_ROLE" : "Role:"
 
     },
 


### PR DESCRIPTION
This change adds reserved attribute names for each user's full name, email address, organization, and organizational role, exposing those attributes within the user menu if set. A new "EMAIL" field type has been added to allow the definition of attributes which accept only email addresses as values.

The database authentication has been modified to add columns to `guacamole_user` for these attributes, and allows the properties to be set by any user with "UPDATE" permission on the user object.