### PR TITLE
GUACAMOLE-314: Update extension API version sanity check to 0.9.13-incubating.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -59,7 +59,7 @@ public class ExtensionModule extends ServletModule {
     private static final List<String> ALLOWED_GUACAMOLE_VERSIONS =
         Collections.unmodifiableList(Arrays.asList(
             "*",
-            "0.9.12-incubating"
+            "0.9.13-incubating"
         ));
 
     /**


### PR DESCRIPTION
Lacking this, none of the extensions whose versions were recently bumped will load.

Whoops.