### PR TITLE
GUACAMOLE-284: Apply database account restrictions when a database account is required.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -89,9 +89,9 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
         ModeledUser user = userService.retrieveUser(authenticationProvider, authenticatedUser);
         if (user != null && !user.isDisabled()) {
 
-            // Apply account restrictions if this extension authenticated
-            // the user OR if an account from this extension is explicitly
-            // required
+            // Account restrictions specific to this extension apply if this
+            // extension authenticated the user OR if an account from this
+            // extension is explicitly required
             if (authenticatedUser instanceof ModeledAuthenticatedUser
                     || environment.isUserRequired()) {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -104,8 +104,16 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
 
         }
 
-        // Update password if password is expired
+        // Veto authentication result if account is required but unavailable
+        // due to account restrictions
         UserModel userModel = user.getModel();
+        if (environment.isUserRequired()
+                && (userModel.isDisabled() || !user.isAccountValid() || !user.isAccountAccessible())) {
+                throw new GuacamoleInvalidCredentialsException("Invalid login",
+                        CredentialsInfo.USERNAME_PASSWORD);
+        }
+
+        // Update password if password is expired
         if (userModel.isExpired() || passwordPolicyService.isPasswordExpired(user))
             userService.resetExpiredPassword(user, authenticatedUser.getCredentials());
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -767,24 +767,26 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     }
 
     /**
-     * Returns whether the user has been disabled. Disabled users are not
-     * allowed to login. Although their account data exists, all login attempts
-     * will fail as if the account does not exist.
+     * Returns whether this user account has been disabled. The credentials of
+     * disabled user accounts are treated as invalid, effectively disabling
+     * that user's access to data for which they would otherwise have
+     * permission.
      *
      * @return
-     *     true if the account is disabled, false otherwise.
+     *     true if this user account has been disabled, false otherwise.
      */
     public boolean isDisabled() {
         return getModel().isDisabled();
     }
 
     /**
-     * Returns whether the user's password has expired. If a user's password is
-     * expired, it must be immediately changed upon login. A user account with
-     * an expired password cannot be used until the password has been changed.
+     * Returns whether this user's password has expired. If a user's password
+     * is expired, it must be immediately changed upon login. A user account
+     * with an expired password cannot be used until the password has been
+     * changed.
      *
      * @return
-     *     true if the user's password has expired, false otherwise.
+     *     true if this user's password has expired, false otherwise.
      */
     public boolean isExpired() {
         return getModel().isExpired();

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -766,4 +766,28 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
         return isActive(getAccessWindowStart(), getAccessWindowEnd());
     }
 
+    /**
+     * Returns whether the user has been disabled. Disabled users are not
+     * allowed to login. Although their account data exists, all login attempts
+     * will fail as if the account does not exist.
+     *
+     * @return
+     *     true if the account is disabled, false otherwise.
+     */
+    public boolean isDisabled() {
+        return getModel().isDisabled();
+    }
+
+    /**
+     * Returns whether the user's password has expired. If a user's password is
+     * expired, it must be immediately changed upon login. A user account with
+     * an expired password cannot be used until the password has been changed.
+     *
+     * @return
+     *     true if the user's password has expired, false otherwise.
+     */
+    public boolean isExpired() {
+        return getModel().isExpired();
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserModel.java
@@ -194,48 +194,51 @@ public class UserModel extends ObjectModel {
     }
 
     /**
-     * Returns whether the user has been disabled. Disabled users are not
-     * allowed to login. Although their account data exists, all login attempts
-     * will fail as if the account does not exist.
+     * Returns whether this user account has been disabled. The credentials of
+     * disabled user accounts are treated as invalid, effectively disabling
+     * that user's access to data for which they would otherwise have
+     * permission.
      *
      * @return
-     *     true if the account is disabled, false otherwise.
+     *     true if this user account is disabled, false otherwise.
      */
     public boolean isDisabled() {
         return disabled;
     }
 
     /**
-     * Sets whether the user is disabled. Disabled users are not allowed to
-     * login. Although their account data exists, all login attempts will fail
-     * as if the account does not exist.
+     * Sets whether this user account has been disabled. The credentials of
+     * disabled user accounts are treated as invalid, effectively disabling
+     * that user's access to data for which they would otherwise have
+     * permission.
      *
      * @param disabled
-     *     true if the account should be disabled, false otherwise.
+     *     true if this user account should be disabled, false otherwise.
      */
     public void setDisabled(boolean disabled) {
         this.disabled = disabled;
     }
 
     /**
-     * Returns whether the user's password has expired. If a user's password is
-     * expired, it must be immediately changed upon login. A user account with
-     * an expired password cannot be used until the password has been changed.
+     * Returns whether this user's password has expired. If a user's password
+     * is expired, it must be immediately changed upon login. A user account
+     * with an expired password cannot be used until the password has been
+     * changed.
      *
      * @return
-     *     true if the user's password has expired, false otherwise.
+     *     true if this user's password has expired, false otherwise.
      */
     public boolean isExpired() {
         return expired;
     }
 
     /**
-     * Sets whether the user's password is expired. If a user's password is
+     * Sets whether this user's password is expired. If a user's password is
      * expired, it must be immediately changed upon login. A user account with
      * an expired password cannot be used until the password has been changed.
      *
      * @param expired
-     *     true to expire the user's password, false otherwise.
+     *     true if this user's password has expired, false otherwise.
      */
     public void setExpired(boolean expired) {
         this.expired = expired;


### PR DESCRIPTION
These changes modify the enforcement of database account restrictions (disabled accounts, scheduling, password expiration) such that they apply even if authentication did not come from the database, so long as [the `mysql-user-required` or `postgresql-user-required` properties](http://guacamole.incubator.apache.org/doc/gug/jdbc-auth.html#jdbc-auth-restrict) are set.