### PR TITLE
GUACAMOLE-341: Make SSO Authentication work and pass through username…

### DIFF
--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
@@ -71,6 +71,9 @@ public class AuthenticationProviderService {
 
             // Get the username from the header configured in guacamole.properties
             String username = request.getHeader(confService.getHttpAuthHeader());
+            
+            //write username to the credentials object to make tokenfilter work
+            credentials.setUsername(username);
 
             if (username != null) {
                 AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();

--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
@@ -72,7 +72,7 @@ public class AuthenticationProviderService {
             // Get the username from the header configured in guacamole.properties
             String username = request.getHeader(confService.getHttpAuthHeader());
             
-            //write username to the credentials object to make tokenfilter work
+            //  Write username to the credentials object to make tokenfilter work
             credentials.setUsername(username);
 
             if (username != null) {

--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
@@ -71,11 +71,10 @@ public class AuthenticationProviderService {
 
             // Get the username from the header configured in guacamole.properties
             String username = request.getHeader(confService.getHttpAuthHeader());
-            
-            //  Write username to the credentials object to make tokenfilter work
-            credentials.setUsername(username);
 
             if (username != null) {
+                //  Write username to the credentials object to make tokenfilter work
+                credentials.setUsername(username);
                 AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
                 authenticatedUser.init(username, credentials);
                 return authenticatedUser;


### PR DESCRIPTION
… to RDP session

To make tokenfilter work with auth-header and noauth module. (needed e.g. for Kerberos authentication through an Apache/Nginx Reverse Proxy, that passes REMOTE_USER header), username must be set in the credentials object, because it is added to the Tokenfilter only if username is not null in the credentials object.
basically make $
{GUAC_USERNAME}
be replaced with the credentials passed though the REMOTE_USER variable.
See also:
https://github.com/glyptodon/guacamole-client/blob/b26a664d66fd14a22eb7300d29aa20390cf408ec/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java#L118
https://github.com/glyptodon/guacamole-client/blob/0.9.12-incubating/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java#L170