### PR TITLE
Allow SSH-Key with at least 4096 bits

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -154,7 +154,7 @@ CREATE TABLE `guacamole_connection_parameter` (
 
   `connection_id`   int(11)       NOT NULL,
   `parameter_name`  varchar(128)  NOT NULL,
-  `parameter_value` varchar(4096) NOT NULL,
+  `parameter_value` varchar(65353) NOT NULL,
 
   PRIMARY KEY (`connection_id`,`parameter_name`),
 


### PR DESCRIPTION
error before updating mysql table :
12:41:39.036 [http-nio-8080-exec-10] ERROR o.a.g.rest.RESTExceptionWrapper - Unexpected internal error: 
### Error updating database.  Cause: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'parameter_value' at row 2
### The error may involve org.apache.guacamole.auth.jdbc.connection.ConnectionParameterMapper.insert-Inline
### The error occurred while setting parameters
### SQL: INSERT INTO guacamole_connection_parameter (             connection_id,             parameter_name,             parameter_value         )         VALUES                                 (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)              ,                  (?,                  ?,                  ?)
### Cause: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'parameter_value' at row 2