### PR TITLE
GUACAMOLE-346: Avoid blocking main thread when seeking.

### DIFF
--- a/doc/guacamole-playback-example/src/main/webapp/index.html
+++ b/doc/guacamole-playback-example/src/main/webapp/index.html
@@ -31,7 +31,13 @@
         <div class="player">
 
             <!-- Player display -->
-            <div id="display"></div>
+            <div id="display">
+                <div class="notification-container">
+                    <div class="seek-notification">
+                        <p>Seek in progress... Click "play" to cancel.</p>
+                    </div>
+                </div>
+            </div>
 
             <!-- Player controls -->
             <div class="controls">

--- a/doc/guacamole-playback-example/src/main/webapp/index.html
+++ b/doc/guacamole-playback-example/src/main/webapp/index.html
@@ -28,7 +28,7 @@
     <body>
 
         <!-- Guacamole recording player -->
-        <div id="player" class="paused">
+        <div id="player">
 
             <!-- Player display -->
             <div id="display">
@@ -38,9 +38,6 @@
                             Seek in progress...
                             <button id="cancel-seek">Cancel</button>
                         </p>
-                    </div>
-                    <div class="paused-notification">
-                        <p>Paused.</p>
                     </div>
                 </div>
             </div>

--- a/doc/guacamole-playback-example/src/main/webapp/index.html
+++ b/doc/guacamole-playback-example/src/main/webapp/index.html
@@ -28,7 +28,7 @@
     <body>
 
         <!-- Guacamole recording player -->
-        <div class="player">
+        <div id="player" class="paused">
 
             <!-- Player display -->
             <div id="display">
@@ -38,6 +38,9 @@
                             Seek in progress...
                             <button id="cancel-seek">Cancel</button>
                         </p>
+                    </div>
+                    <div class="paused-notification">
+                        <p>Paused.</p>
                     </div>
                 </div>
             </div>

--- a/doc/guacamole-playback-example/src/main/webapp/index.html
+++ b/doc/guacamole-playback-example/src/main/webapp/index.html
@@ -34,7 +34,10 @@
             <div id="display">
                 <div class="notification-container">
                     <div class="seek-notification">
-                        <p>Seek in progress... Click "play" to cancel.</p>
+                        <p>
+                            Seek in progress...
+                            <button id="cancel-seek">Cancel</button>
+                        </p>
                     </div>
                 </div>
             </div>

--- a/doc/guacamole-playback-example/src/main/webapp/playback.css
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.css
@@ -34,7 +34,6 @@
     bottom: 0;
 }
 
-#player .paused-notification,
 #player .seek-notification {
 
     color: white;
@@ -50,11 +49,6 @@
     display: table;
 }
 
-#player.paused .paused-notification {
-    display: table;
-}
-
-#player .paused-notification p,
 #player .seek-notification p {
     display: table-cell;
     text-align: center;

--- a/doc/guacamole-playback-example/src/main/webapp/playback.css
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.css
@@ -21,6 +21,41 @@
     width: 640px;
 }
 
+.player #display {
+    position: relative;
+}
+
+.player .notification-container {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+}
+
+.player .seek-notification {
+
+    color: white;
+    background: rgba(0, 0, 0, 0.75);
+
+    display: none; /* Initially hidden */
+    width: 100%;
+    height: 100%;
+
+}
+
+.player #display.seeking .seek-notification {
+    display: table;
+}
+
+.player .seek-notification p {
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+    font-family: sans-serif;
+}
+
 .player .controls {
 
     width: 100%;

--- a/doc/guacamole-playback-example/src/main/webapp/playback.css
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.css
@@ -17,15 +17,15 @@
  * under the License.
  */
 
-.player {
+#player {
     width: 640px;
 }
 
-.player #display {
+#display {
     position: relative;
 }
 
-.player .notification-container {
+#player .notification-container {
     position: absolute;
     z-index: 1;
     top: 0;
@@ -34,7 +34,8 @@
     bottom: 0;
 }
 
-.player .seek-notification {
+#player .paused-notification,
+#player .seek-notification {
 
     color: white;
     background: rgba(0, 0, 0, 0.75);
@@ -45,18 +46,23 @@
 
 }
 
-.player #display.seeking .seek-notification {
+#player.seeking .seek-notification {
     display: table;
 }
 
-.player .seek-notification p {
+#player.paused .paused-notification {
+    display: table;
+}
+
+#player .paused-notification p,
+#player .seek-notification p {
     display: table-cell;
     text-align: center;
     vertical-align: middle;
     font-family: sans-serif;
 }
 
-.player .controls {
+#player .controls {
 
     width: 100%;
 
@@ -87,11 +93,11 @@
 
 }
 
-.player .controls > * {
+#player .controls > * {
     margin: 0.25em;
 }
 
-.player .controls #position-slider {
+#player .controls #position-slider {
     -ms-flex: 1 1 auto;
     -moz-box-flex: 1;
     -webkit-box-flex: 1;
@@ -99,16 +105,16 @@
     flex: 1 1 auto;
 }
 
-.player .controls #play-pause {
+#player .controls #play-pause {
     margin-left: 0;
     min-width: 5em;
 }
 
-.player .controls #position,
-.player .controls #duration {
+#player .controls #position,
+#player .controls #duration {
     font-family: monospace;
 }
 
-.player .controls #duration {
+#player .controls #duration {
     margin-right: 0;
 }

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -179,10 +179,9 @@
             recording.pause();
     };
 
-    // Cancel seek operation when cancel button is clicked
+    // Resume playback when cancel button is clicked
     cancelSeek.onclick = function cancelSeekOperation(e) {
-        player.className = 'paused';
-        recording.pause();
+        recording.play();
         e.stopPropagation();
     };
 

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -148,6 +148,7 @@
     // If playing, the play/pause button should read "Pause"
     recording.onplay = function() {
         playPause.textContent = 'Pause';
+        display.classList.remove('seeking');
     };
 
     // If paused, the play/pause button should read "Play"
@@ -189,7 +190,17 @@
 
     // Seek within recording if slider is moved
     positionSlider.onchange = function sliderPositionChanged() {
-        recording.seek(positionSlider.value);
+
+        // Seek is in progress
+        display.classList.add('seeking');
+
+        // Request seek
+        recording.seek(positionSlider.value, function seekComplete() {
+
+            // Seek has completed
+            display.classList.remove('seeking');
+
+        });
     };
 
 })();

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -162,13 +162,11 @@
     // If playing, the play/pause button should read "Pause"
     recording.onplay = function() {
         playPause.textContent = 'Pause';
-        player.className = 'playing';
     };
 
     // If paused, the play/pause button should read "Play"
     recording.onpause = function() {
         playPause.textContent = 'Play';
-        player.className = 'paused';
     };
 
     // Toggle play/pause when display or button are clicked
@@ -182,6 +180,7 @@
     // Resume playback when cancel button is clicked
     cancelSeek.onclick = function cancelSeekOperation(e) {
         recording.play();
+        player.className = '';
         e.stopPropagation();
     };
 
@@ -213,7 +212,12 @@
     positionSlider.onchange = function sliderPositionChanged() {
 
         // Request seek
-        recording.seek(positionSlider.value);
+        recording.seek(positionSlider.value, function seekComplete() {
+
+            // Seek has completed
+            player.className = '';
+
+        });
 
         // Seek is in progress
         player.className = 'seeking';

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -161,6 +161,7 @@
     // If paused, the play/pause button should read "Play"
     recording.onpause = function() {
         playPause.textContent = 'Play';
+        display.classList.remove('seeking');
     };
 
     // Toggle play/pause when display or button are clicked
@@ -173,6 +174,7 @@
 
     // Cancel seek operation when cancel button is clicked
     cancelSeek.onclick = function cancelSeekOperation(e) {
+        display.classList.remove('seeking');
         recording.pause();
         e.stopPropagation();
     };
@@ -204,9 +206,6 @@
     // Seek within recording if slider is moved
     positionSlider.onchange = function sliderPositionChanged() {
 
-        // Seek is in progress
-        display.classList.add('seeking');
-
         // Request seek
         recording.seek(positionSlider.value, function seekComplete() {
 
@@ -214,6 +213,10 @@
             display.classList.remove('seeking');
 
         });
+
+        // Seek is in progress
+        display.classList.add('seeking');
+
     };
 
 })();

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -42,6 +42,13 @@
     var playPause = document.getElementById('play-pause');
 
     /**
+     * Button for cancelling in-progress seek operations.
+     *
+     * @type Element
+     */
+    var cancelSeek = document.getElementById('cancel-seek');
+
+    /**
      * Text status display indicating the current playback position within the
      * recording.
      *
@@ -162,6 +169,12 @@
             recording.play();
         else
             recording.pause();
+    };
+
+    // Cancel seek operation when cancel button is clicked
+    cancelSeek.onclick = function cancelSeekOperation(e) {
+        recording.pause();
+        e.stopPropagation();
     };
 
     // Fit display within containing div

--- a/doc/guacamole-playback-example/src/main/webapp/playback.js
+++ b/doc/guacamole-playback-example/src/main/webapp/playback.js
@@ -28,6 +28,13 @@
     var RECORDING_URL = 'recording.guac';
 
     /**
+     * The element representing the session recording player.
+     *
+     * @type Element
+     */
+    var player = document.getElementById('player');
+
+    /**
      * The element which will contain the recording display.
      *
      * @type Element
@@ -155,13 +162,13 @@
     // If playing, the play/pause button should read "Pause"
     recording.onplay = function() {
         playPause.textContent = 'Pause';
-        display.classList.remove('seeking');
+        player.className = 'playing';
     };
 
     // If paused, the play/pause button should read "Play"
     recording.onpause = function() {
         playPause.textContent = 'Play';
-        display.classList.remove('seeking');
+        player.className = 'paused';
     };
 
     // Toggle play/pause when display or button are clicked
@@ -174,7 +181,7 @@
 
     // Cancel seek operation when cancel button is clicked
     cancelSeek.onclick = function cancelSeekOperation(e) {
-        display.classList.remove('seeking');
+        player.className = 'paused';
         recording.pause();
         e.stopPropagation();
     };
@@ -207,15 +214,10 @@
     positionSlider.onchange = function sliderPositionChanged() {
 
         // Request seek
-        recording.seek(positionSlider.value, function seekComplete() {
-
-            // Seek has completed
-            display.classList.remove('seeking');
-
-        });
+        recording.seek(positionSlider.value);
 
         // Seek is in progress
-        display.classList.add('seeking');
+        player.className = 'seeking';
 
     };
 

--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -325,7 +325,7 @@ Guacamole.SessionRecording = function SessionRecording(tunnel) {
      *     The index of the frame which should become the new playback
      *     position.
      *
-     * @param {function} [callback]
+     * @param {function} callback
      *     The callback to invoke once the seek operation has completed.
      */
     var seekToFrame = function seekToFrame(index, callback) {
@@ -387,8 +387,7 @@ Guacamole.SessionRecording = function SessionRecording(tunnel) {
             else {
 
                 // Notify that the requested seek has completed
-                if (callback)
-                    callback();
+                callback();
 
             }
 

--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -330,35 +330,35 @@ Guacamole.SessionRecording = function SessionRecording(tunnel) {
      */
     var seekToFrame = function seekToFrame(index, callback) {
 
-        var startIndex;
-
         // Abort any in-progress seek
         abortSeek();
 
-        // Back up until startIndex represents current state
-        for (startIndex = index; startIndex >= 0; startIndex--) {
-
-            var frame = frames[startIndex];
-
-            // If we've reached the current frame, startIndex represents
-            // current state by definition
-            if (startIndex === currentFrame)
-                break;
-
-            // If frame has associated absolute state, make that frame the
-            // current state
-            if (frame.clientState) {
-                playbackClient.importState(frame.clientState);
-                break;
-            }
-
-        }
-
-        // Advance to frame index after current state
-        startIndex++;
-
         // Replay frames asynchronously
         seekTimeout = window.setTimeout(function continueSeek() {
+
+            var startIndex;
+
+            // Back up until startIndex represents current state
+            for (startIndex = index; startIndex >= 0; startIndex--) {
+
+                var frame = frames[startIndex];
+
+                // If we've reached the current frame, startIndex represents
+                // current state by definition
+                if (startIndex === currentFrame)
+                    break;
+
+                // If frame has associated absolute state, make that frame the
+                // current state
+                if (frame.clientState) {
+                    playbackClient.importState(frame.clientState);
+                    break;
+                }
+
+            }
+
+            // Advance to frame index after current state
+            startIndex++;
 
             var startTime = new Date().getTime();
 

--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -415,32 +415,34 @@ Guacamole.SessionRecording = function SessionRecording(tunnel) {
     var continuePlayback = function continuePlayback() {
 
         // Advance to next frame
-        seekToFrame(currentFrame + 1);
+        seekToFrame(currentFrame + 1, function playbackSeekComplete() {
 
-        // If frames remain after advancing, schedule next frame
-        if (currentFrame + 1 < frames.length) {
+            // If frames remain after advancing, schedule next frame
+            if (currentFrame + 1 < frames.length) {
 
-            // Pull the upcoming frame
-            var next = frames[currentFrame + 1];
+                // Pull the upcoming frame
+                var next = frames[currentFrame + 1];
 
-            // Calculate the real timestamp corresponding to when the next
-            // frame begins
-            var nextRealTimestamp = next.timestamp - startVideoTimestamp + startRealTimestamp;
+                // Calculate the real timestamp corresponding to when the next
+                // frame begins
+                var nextRealTimestamp = next.timestamp - startVideoTimestamp + startRealTimestamp;
 
-            // Calculate the relative delay between the current time and
-            // the next frame start
-            var delay = Math.max(nextRealTimestamp - new Date().getTime(), 0);
+                // Calculate the relative delay between the current time and
+                // the next frame start
+                var delay = Math.max(nextRealTimestamp - new Date().getTime(), 0);
 
-            // Advance to next frame after enough time has elapsed
-            playbackTimeout = window.setTimeout(function frameDelayElapsed() {
-                continuePlayback();
-            }, delay);
+                // Advance to next frame after enough time has elapsed
+                playbackTimeout = window.setTimeout(function frameDelayElapsed() {
+                    continuePlayback();
+                }, delay);
 
-        }
+            }
 
-        // Otherwise stop playback
-        else
-            recording.pause();
+            // Otherwise stop playback
+            else
+                recording.pause();
+
+        });
 
     };
 

--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -384,12 +384,9 @@ Guacamole.SessionRecording = function SessionRecording(tunnel) {
             if (currentFrame !== index)
                 seekToFrame(index, callback);
 
-            else {
-
-                // Notify that the requested seek has completed
+            // Notify that the requested seek has completed
+            else
                 callback();
-
-            }
 
         }, 0);
 


### PR DESCRIPTION
For sufficiently large recordings, the existing implementation of `Guacamole.SessionRecording` can potentially block the main thread to the point that the script appears to have hung. This change modifies `Guacamole.SessionRecording` such that seek operations are performed asynchronously, with completion of the seek reported through a callback.

The playback example has been modified accordingly, providing a notification and cancel button for in-progress seek operations.