### PR TITLE
GUACAMOLE-339: Add Remote Host to Connection History Table

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordModel.java
@@ -64,6 +64,11 @@ public class ConnectionRecordModel {
     private String username;
 
     /**
+     * The remote host associated with this connection record.
+     */
+    private String remoteHost;
+
+    /**
      * The time the connection was initiated by the associated user.
      */
     private Date startDate;
@@ -214,6 +219,26 @@ public class ConnectionRecordModel {
      */
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    /**
+     * Returns the remote host associated with this connection record.
+     *
+     * @return
+     *     The remote host associated with this connection record.
+     */
+    public String getRemoteHost() {
+        return remoteHost;
+    }
+
+    /**
+     * Sets the remote host associated with this connection record.
+     *
+     * @param remoteHost
+     *     The remote host to associate with this connection record.
+     */
+    public void setRemoteHost(String remoteHost) {
+        this.remoteHost = remoteHost;
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnectionRecord.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnectionRecord.java
@@ -77,7 +77,7 @@ public class ModeledConnectionRecord implements ConnectionRecord {
 
     @Override
     public String getRemoteHost() {
-        return null;
+        return model.getRemoteHost();
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -306,6 +306,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
         recordModel.setUsername(record.getUsername());
         recordModel.setConnectionIdentifier(record.getConnectionIdentifier());
         recordModel.setConnectionName(record.getConnectionName());
+        recordModel.setRemoteHost(record.getRemoteHost());
         recordModel.setSharingProfileIdentifier(record.getSharingProfileIdentifier());
         recordModel.setSharingProfileName(record.getSharingProfileName());
         recordModel.setStartDate(record.getStartDate());

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -322,7 +322,7 @@ CREATE TABLE `guacamole_connection_history` (
   `history_id`           int(11)      NOT NULL AUTO_INCREMENT,
   `user_id`              int(11)      DEFAULT NULL,
   `username`             varchar(128) NOT NULL,
-  `remote_host`          varchar(128) DEFAULT NULL,
+  `remote_host`          varchar(256) DEFAULT NULL,
   `connection_id`        int(11)      DEFAULT NULL,
   `connection_name`      varchar(128) NOT NULL,
   `sharing_profile_id`   int(11)      DEFAULT NULL,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -322,6 +322,7 @@ CREATE TABLE `guacamole_connection_history` (
   `history_id`           int(11)      NOT NULL AUTO_INCREMENT,
   `user_id`              int(11)      DEFAULT NULL,
   `username`             varchar(128) NOT NULL,
+  `remote_host`          varchar(128) DEFAULT NULL,
   `connection_id`        int(11)      DEFAULT NULL,
   `connection_name`      varchar(128) NOT NULL,
   `sharing_profile_id`   int(11)      DEFAULT NULL,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.14.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.14.sql
@@ -36,4 +36,4 @@ ALTER TABLE guacamole_connection
 --
 
 ALTER TABLE guacamole_connection_history
-    ADD COLUMN remote_host VARCHAR(128) DEFAULT NULL;
+    ADD COLUMN remote_host VARCHAR(256) DEFAULT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.14.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.14.sql
@@ -30,3 +30,10 @@ ALTER TABLE guacamole_connection
 
 ALTER TABLE guacamole_connection
     ADD COLUMN failover_only BOOLEAN NOT NULL DEFAULT 0;
+
+--
+-- Add remote_host to connection history
+--
+
+ALTER TABLE guacamole_connection_history
+    ADD COLUMN remote_host VARCHAR(128) DEFAULT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
@@ -27,6 +27,7 @@
     <resultMap id="ConnectionRecordResultMap" type="org.apache.guacamole.auth.jdbc.connection.ConnectionRecordModel">
         <result column="connection_id"        property="connectionIdentifier"     jdbcType="INTEGER"/>
         <result column="connection_name"      property="connectionName"           jdbcType="VARCHAR"/>
+        <result column="remote_host"          property="remoteHost"               jdbcType="VARCHAR"/>
         <result column="sharing_profile_id"   property="sharingProfileIdentifier" jdbcType="INTEGER"/>
         <result column="sharing_profile_name" property="sharingProfileName"       jdbcType="VARCHAR"/>
         <result column="user_id"              property="userID"                   jdbcType="INTEGER"/>
@@ -41,6 +42,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,
@@ -62,6 +64,7 @@
         INSERT INTO guacamole_connection_history (
             connection_id,
             connection_name,
+            remote_host,
             sharing_profile_id,
             sharing_profile_name,
             user_id,
@@ -72,6 +75,7 @@
         VALUES (
             #{record.connectionIdentifier,jdbcType=VARCHAR},
             #{record.connectionName,jdbcType=VARCHAR},
+            #{record.remoteHost,jdbcType=VARCHAR},
             #{record.sharingProfileIdentifier,jdbcType=VARCHAR},
             #{record.sharingProfileName,jdbcType=VARCHAR},
             (SELECT user_id FROM guacamole_user
@@ -89,6 +93,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,
@@ -146,6 +151,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -381,6 +381,7 @@ CREATE TABLE guacamole_connection_history (
   history_id           serial       NOT NULL,
   user_id              integer      DEFAULT NULL,
   username             varchar(128) NOT NULL,
+  remote_host          varchar(128) DEFAULT NULL,
   connection_id        integer      DEFAULT NULL,
   connection_name      varchar(128) NOT NULL,
   sharing_profile_id   integer      DEFAULT NULL,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -381,7 +381,7 @@ CREATE TABLE guacamole_connection_history (
   history_id           serial       NOT NULL,
   user_id              integer      DEFAULT NULL,
   username             varchar(128) NOT NULL,
-  remote_host          varchar(128) DEFAULT NULL,
+  remote_host          varchar(256) DEFAULT NULL,
   connection_id        integer      DEFAULT NULL,
   connection_name      varchar(128) NOT NULL,
   sharing_profile_id   integer      DEFAULT NULL,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.14.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.14.sql
@@ -36,4 +36,4 @@ ALTER TABLE guacamole_connection
 --
 
 ALTER TABLE guacamole_connection_history
-    ADD COLUMN remote_host VARCHAR(128) DEFAULT NULL;
+    ADD COLUMN remote_host VARCHAR(256) DEFAULT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.14.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.14.sql
@@ -30,3 +30,10 @@ ALTER TABLE guacamole_connection
 
 ALTER TABLE guacamole_connection
     ADD COLUMN failover_only BOOLEAN NOT NULL DEFAULT FALSE;
+
+--
+-- Add remote_host to connection history
+--
+
+ALTER TABLE guacamole_connection_history
+    ADD COLUMN remote_host VARCHAR(128) DEFAULT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
@@ -27,6 +27,7 @@
     <resultMap id="ConnectionRecordResultMap" type="org.apache.guacamole.auth.jdbc.connection.ConnectionRecordModel">
         <result column="connection_id"        property="connectionIdentifier"     jdbcType="INTEGER"/>
         <result column="connection_name"      property="connectionName"           jdbcType="VARCHAR"/>
+        <result column="remote_host"          property="remoteHost"               jdbcType="VARCHAR"/>
         <result column="sharing_profile_id"   property="sharingProfileIdentifier" jdbcType="INTEGER"/>
         <result column="sharing_profile_name" property="sharingProfileName"       jdbcType="VARCHAR"/>
         <result column="user_id"              property="userID"                   jdbcType="INTEGER"/>
@@ -41,6 +42,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,
@@ -62,6 +64,7 @@
         INSERT INTO guacamole_connection_history (
             connection_id,
             connection_name,
+            remote_host,
             sharing_profile_id,
             sharing_profile_name,
             user_id,
@@ -72,6 +75,7 @@
         VALUES (
             #{record.connectionIdentifier,jdbcType=INTEGER}::integer,
             #{record.connectionName,jdbcType=VARCHAR},
+            #{record.remoteHost,jdbcType=VARCHAR},
             #{record.sharingProfileIdentifier,jdbcType=INTEGER}::integer,
             #{record.sharingProfileName,jdbcType=VARCHAR},
             (SELECT user_id FROM guacamole_user
@@ -89,6 +93,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,
@@ -144,6 +149,7 @@
         SELECT
             guacamole_connection_history.connection_id,
             guacamole_connection_history.connection_name,
+            guacamole_connection_history.remote_host,
             guacamole_connection_history.sharing_profile_id,
             guacamole_connection_history.sharing_profile_name,
             guacamole_connection_history.user_id,

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -72,6 +72,7 @@
                     <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_USERNAME' | translate}}</th>
                     <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_START' | translate}}</th>
                     <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_DURATION' | translate}}</th>
+                    <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_REMOTEHOST' | translate}}</th>
                 </tr>
             </thead>
             <tbody>
@@ -81,6 +82,7 @@
                     <td class="duration"
                         translate="{{wrapper.durationText}}"
                         translate-values="{VALUE: wrapper.duration.value, UNIT: wrapper.duration.unit}"></td>
+                    <td class="remoteHost">{{wrapper.entry.remoteHost}}</td>
                 </tr>
             </tbody>
         </table>

--- a/guacamole/src/main/webapp/app/rest/types/ConnectionHistoryEntry.js
+++ b/guacamole/src/main/webapp/app/rest/types/ConnectionHistoryEntry.js
@@ -53,6 +53,13 @@ angular.module('rest').factory('ConnectionHistoryEntry', [function defineConnect
         this.connectionName = template.connectionName;
 
         /**
+         * The remote host associated with this history entry.
+         *
+         * @type String
+         */
+        this.remoteHost = template.remoteHost;
+
+        /**
          * The time that usage began, in seconds since 1970-01-01 00:00:00 UTC.
          *
          * @type Number 

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
@@ -84,7 +84,8 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                 '-startDate',
                 '-duration',
                 'username',
-                'connectionName'
+                'connectionName',
+                'remoteHost'
             ]);
 
             // Get session date format
@@ -192,6 +193,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                     'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_STARTDATE',
                     'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_DURATION',
                     'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_CONNECTION_NAME',
+                    'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_REMOTEHOST',
                     'SETTINGS_CONNECTION_HISTORY.FILENAME_HISTORY_CSV'
                 ]).then(function headerTranslated(translations) {
 
@@ -200,7 +202,8 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                         translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_USERNAME'],
                         translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_STARTDATE'],
                         translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_DURATION'],
-                        translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_CONNECTION_NAME']
+                        translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_CONNECTION_NAME'],
+                        translations['SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_REMOTEHOST']
                     ]];
 
                     // Add rows for all history entries, using the same sort
@@ -215,7 +218,8 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                                 historyEntryWrapper.username,
                                 $filter('date')(historyEntryWrapper.startDate, $scope.dateFormat),
                                 historyEntryWrapper.duration / 1000,
-                                historyEntryWrapper.connectionName
+                                historyEntryWrapper.connectionName,
+                                historyEntryWrapper.remoteHost
                             ]);
                         }
                     );

--- a/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
@@ -29,6 +29,9 @@
                     <th guac-sort-order="order" guac-sort-property="'connectionName'">
                         {{'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_CONNECTION_NAME' | translate}}
                     </th>
+                    <th guac-sort-order="order" guac-sort-property="'remoteHost'">
+                        {{'SETTINGS_CONNECTION_HISTORY.TABLE_HEADER_SESSION_REMOTEHOST' | translate}}
+                    </th>
                 </tr>
             </thead>
             <tbody ng-class="{loading: !isLoaded()}">
@@ -38,6 +41,7 @@
                     <td translate="{{historyEntryWrapper.readableDurationText}}"
                         translate-values="{VALUE: historyEntryWrapper.readableDuration.value, UNIT: historyEntryWrapper.readableDuration.unit}"></td>
                     <td>{{historyEntryWrapper.connectionName}}</td>
+                    <td>{{historyEntryWrapper.remoteHost}}</td>
                 </tr>
             </tbody>
         </table>

--- a/guacamole/src/main/webapp/app/settings/types/ConnectionHistoryEntryWrapper.js
+++ b/guacamole/src/main/webapp/app/settings/types/ConnectionHistoryEntryWrapper.js
@@ -51,6 +51,13 @@ angular.module('settings').factory('ConnectionHistoryEntryWrapper', ['$injector'
         this.connectionName = historyEntry.connectionName;
 
         /**
+         * The remote host associated with this history entry.
+         *
+         * @type String
+         */
+        this.remoteHost = historyEntry.remoteHost;
+
+        /**
          * The username of the user associated with this particular usage of
          * the connection.
          *

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -220,9 +220,10 @@
         "SECTION_HEADER_HISTORY"         : "Usage History",
         "SECTION_HEADER_PARAMETERS"      : "Parameters",
 
-        "TABLE_HEADER_HISTORY_USERNAME" : "Username",
-        "TABLE_HEADER_HISTORY_START"    : "Start Time",
-        "TABLE_HEADER_HISTORY_DURATION" : "Duration",
+        "TABLE_HEADER_HISTORY_USERNAME"   : "Username",
+        "TABLE_HEADER_HISTORY_START"      : "Start Time",
+        "TABLE_HEADER_HISTORY_DURATION"   : "Duration",
+        "TABLE_HEADER_HISTORY_REMOTEHOST" : "Remote Host",
 
         "TEXT_CONFIRM_DELETE"   : "Connections cannot be restored after they have been deleted. Are you sure you want to delete this connection?",
         "TEXT_HISTORY_DURATION" : "@:APP.TEXT_HISTORY_DURATION"
@@ -598,6 +599,7 @@
 
         "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Connection name",
         "TABLE_HEADER_SESSION_DURATION"        : "Duration",
+        "TABLE_HEADER_SESSION_REMOTEHOST"      : "Remote host",
         "TABLE_HEADER_SESSION_STARTDATE"       : "Start time",
         "TABLE_HEADER_SESSION_USERNAME"        : "Username",
 


### PR DESCRIPTION
This pull request adds the necessary fields and methods to the JDBC module to track the remote host in the connection history table, and to display it in the various history output tables in the client interface.