### PR TITLE
GUACAMOLE-358: Fix issue with 404 errors from REST API

### DIFF
--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
@@ -192,6 +192,9 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                 $scope.canChangePassword = PermissionSet.hasUserPermission(permissions,
                         PermissionSet.ObjectPermissionType.UPDATE, username);
                         
+            })
+            .error(function permissionsFailed(error) {
+                $scope.canChangePassword = false;
             });
 
             /**


### PR DESCRIPTION
This pull request adds a new SimpleUserContext to the CAS extension, instead of returning null, which seems to resolve the issue reported in this JIRA issue with errors trying to access the Settings page in Guacamole.