### PR TITLE
GUACAMOLE-355: Catch CAS Errors and Display Them

### DIFF
--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -113,7 +113,7 @@ public class TicketValidationService {
         }
         catch (Throwable t) {
             logger.error("Error validating ticket with CAS server: {}", t.getMessage());
-            throw new GuacamoleInsufficientCredentialsException("Error validating ticket with CAS server.", t, CredentialsInfo.USERNAME_PASSWORD);
+            throw new GuacamoleInsufficientCredentialsException("CAS login failed.", CredentialsInfo.USERNAME_PASSWORD);
         }
 
     }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -34,7 +34,7 @@ import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.cas.conf.ConfigurationService;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
-import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.Cas20ProxyTicketValidator;
@@ -113,7 +113,7 @@ public class TicketValidationService {
         }
         catch (Throwable t) {
             logger.error("Error validating ticket with CAS server: {}", t.getMessage());
-            throw new GuacamoleInsufficientCredentialsException("CAS login failed.", CredentialsInfo.USERNAME_PASSWORD);
+            throw new GuacamoleInvalidCredentialsException("CAS login failed.", CredentialsInfo.USERNAME_PASSWORD);
         }
 
     }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -33,6 +33,8 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.cas.conf.ConfigurationService;
 import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.Cas20ProxyTicketValidator;
@@ -108,6 +110,10 @@ public class TicketValidationService {
         } 
         catch (TicketValidationException e) {
             throw new GuacamoleException("Ticket validation failed.", e);
+        }
+        catch (Throwable t) {
+            logger.error("Error validating ticket with CAS server: {}", t.getMessage());
+            throw new GuacamoleInsufficientCredentialsException("Error validating ticket with CAS server.", t, CredentialsInfo.USERNAME_PASSWORD);
         }
 
     }


### PR DESCRIPTION
This PR catches the errors thrown by the CAS module and rethrows them as Guacmaole exceptions, and displays an error message in the login box.