### PR TITLE
GUACAMOLE-310: Fix clipboard handling of newlines.

### DIFF
--- a/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
+++ b/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
@@ -135,14 +135,23 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
      */
     var selectAll = function selectAll(element) {
 
-        // Generate a range which selects all nodes within the given element
-        var range = document.createRange();
-        range.selectNodeContents(element);
+        // Use the select() function defined for input elements, if available
+        if (element.select)
+            element.select();
 
-        // Replace any current selection with the generated range
-        var selection = $window.getSelection();
-        selection.removeAllRanges();
-        selection.addRange(range);
+        // Fallback to manual manipulation of the selection
+        else {
+
+            // Generate a range which selects all nodes within the given element
+            var range = document.createRange();
+            range.selectNodeContents(element);
+
+            // Replace any current selection with the generated range
+            var selection = $window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+
+        }
 
     };
 
@@ -175,6 +184,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
         }
 
         // Select all data within the clipboard target
+        clipboardContent.focus();
         selectAll(clipboardContent);
 
         // Attempt to copy data from clipboard element into local clipboard

--- a/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
+++ b/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
@@ -57,10 +57,9 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
      *
      * @type Element
      */
-    var clipboardContent = document.createElement('div');
+    var clipboardContent = document.createElement('textarea');
 
     // Ensure clipboard target is selectable but not visible
-    clipboardContent.setAttribute('contenteditable', 'true');
     clipboardContent.className = 'clipboard-service-target';
 
     // Add clipboard target to DOM
@@ -167,7 +166,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
 
         // Copy the given value into the clipboard DOM element
         if (typeof data.data === 'string')
-            clipboardContent.textContent = data.data;
+            clipboardContent.value = data.data;
         else {
             clipboardContent.innerHTML = '';
             var img = document.createElement('img');
@@ -400,7 +399,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
             pushSelection();
 
             // Clear and select the clipboard DOM element
-            clipboardContent.innerHTML = '';
+            clipboardContent.value = '';
             clipboardContent.focus();
             selectAll(clipboardContent);
 
@@ -431,7 +430,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
                 else
                     deferred.resolve(new ClipboardData({
                         type : 'text/plain',
-                        data : clipboardContent.textContent
+                        data : clipboardContent.value
                     }));
 
             }

--- a/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
+++ b/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
@@ -52,10 +52,10 @@
 
 .clipboard-service-target {
     position: fixed;
-    left: -1px;
-    right: -1px;
-    width: 1px;
-    height: 1px;
+    left: -1em;
+    right: -1em;
+    width: 1em;
+    height: 1em;
     white-space: pre;
     overflow: hidden;
 }


### PR DESCRIPTION
As reported in [GUACAMOLE-310](https://issues.apache.org/jira/browse/GUACAMOLE-310), newlines are being stripped from clipboard data copied using the [W3C Clipboard API](https://www.w3.org/TR/clipboard-apis/). This makes clipboard use cumbersome for users where the browser provides direct integration of the clipboard, such as IE11 or Chrome with the [Clipboard Permission Manager](https://chrome.google.com/webstore/detail/clipboard-permission-mana/ipbhneeanpgkaleihlknhjiaamobkceh) extension.

This is due to newlines being stripped from `textContent` of a `<div>` despite `white-space: pre` being set. As this did indeed work before, this seems to be a recent browser behavior change. By reverting back to using a `<textarea>` the clipboard event target, newlines work as expected.