### PR TITLE
GUACAMOLE-128: Fix clipboard bounce.

### DIFF
--- a/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
+++ b/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
@@ -86,6 +86,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
     };
 
     // Prevent events generated due to execCommand() from disturbing external things
+    clipboardContent.addEventListener('cut',   stopEventPropagation);
     clipboardContent.addEventListener('copy',  stopEventPropagation);
     clipboardContent.addEventListener('paste', stopEventPropagation);
 

--- a/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
+++ b/guacamole/src/main/webapp/app/clipboard/services/clipboardService.js
@@ -45,6 +45,14 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
     var CLIPBOARD_READ_DELAY = 100;
 
     /**
+     * The promise associated with the current pending clipboard read attempt.
+     * If no clipboard read is active, this will be null.
+     *
+     * @type Promise.<ClipboardData>
+     */
+    var pendingRead = null;
+
+    /**
      * Reference to the window.document object.
      *
      * @private
@@ -398,7 +406,15 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
      */
     service.getLocalClipboard = function getLocalClipboard() {
 
+        // If the clipboard is already being read, do not overlap the read
+        // attempts; instead share the result across all requests
+        if (pendingRead)
+            return pendingRead;
+
         var deferred = $q.defer();
+
+        // Mark read attempt as in progress
+        pendingRead = deferred.promise;
 
         // Wait for the next event queue run before attempting to read
         // clipboard data (in case the copy/cut has not yet completed)
@@ -466,6 +482,9 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
                 clipboardContent.blur();
                 originalElement.focus();
                 popSelection();
+
+                // No read is pending any longer
+                pendingRead = null;
 
             });
 

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -137,8 +137,8 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
 
     // Attempt to read the clipboard if it may have changed
     $window.addEventListener('load',  checkClipboard, true);
-    $window.addEventListener('copy',  checkClipboard, true);
-    $window.addEventListener('cut',   checkClipboard, true);
+    $window.addEventListener('copy',  checkClipboard);
+    $window.addEventListener('cut',   checkClipboard);
     $window.addEventListener('focus', function focusGained(e) {
 
         // Only recheck clipboard if it's the window itself that gained focus


### PR DESCRIPTION
Under IE11, the clipboard integration code can use an unusual amount of CPU, to the point of crippling the browser. This is due to a number of factors:

1. Copy/paste within content-editable `<div>` in IE11 is extremely slow (this is partly addressed by #185).
2. Attempts to read/write the clipboard result in events which the Guacamole interface listens on to determine whether to re-read the clipboard, resulting in a never-ending read/write cycle, even though the clipboard is not actually changing.
3. Depending on timing, clipboard read attempts may overlap. Since all read operations share the same event target, this may result in clipboard contents being duplicated (pasted multiple times within the event target prior to reading the event target contents).

This change switches event handling order to ensure that read/write attempts will not themselves result in yet more attempts, and modifies `getLocalClipboard()` to consistently return the same promise while a read attempt is still in progress (thus avoiding overlap).
