### PR TITLE
GUACAMOLE-385: Add a convenience filter to cache the contents of HTTP requests

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -306,7 +306,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain) {
             var message_xmlhttprequest = new XMLHttpRequest();
             message_xmlhttprequest.open("POST", TUNNEL_WRITE + tunnel.uuid);
             message_xmlhttprequest.withCredentials = withCredentials;
-            message_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
+            message_xmlhttprequest.setRequestHeader("Content-type", "application/octet-stream");
 
             // Once response received, send next queued event.
             message_xmlhttprequest.onreadystatechange = function() {


### PR DESCRIPTION
Some implementations of the HTTP servlet request do not allow a free use of the getInputStream() and getParameter() methods. This is especially annoying in Apache Tomcat >= 7 and Servlet 3.0, where invoking the getParameter() method consumes the InputStream (making later uses of it fail) and consuming the InputStream makes later getParameter() calls fail to find the parameters, as the request body has been consumed.

This causes issues for tunnel servlets that need to access the request parameters, commonly used to pass authentication tokens or additional info provided in the "tunnel.connect()" call, as the tunnel needs later access to the request input stream. Applications using the popular Spring framework may be affected too, since some of its common filters also access the request parameters.

This PR adds a convenience filter that caches the request contents to allow free access to its body and parameters, so servlets and filters can access the request information normally. Without this caching, if the request parameters are accessed in the tunnel servlet or a previous filter, the `doWrite` method in the base HTTP tunnel servlet always gets an already consumed InputStream and does not write anything to the socket, causing an eventual timeout in the client.