### PR TITLE
GUACAMOLE-395: Populate "expired" property of Guacamole users defined via MySQL / MariaDB.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml
@@ -31,6 +31,7 @@
         <result column="password_salt"       property="passwordSalt"       jdbcType="BINARY"/>
         <result column="password_date"       property="passwordDate"       jdbcType="TIMESTAMP"/>
         <result column="disabled"            property="disabled"           jdbcType="BOOLEAN"/>
+        <result column="expired"             property="expired"            jdbcType="BOOLEAN"/>
         <result column="access_window_start" property="accessWindowStart"  jdbcType="TIME"/>
         <result column="access_window_end"   property="accessWindowEnd"    jdbcType="TIME"/>
         <result column="valid_from"          property="validFrom"          jdbcType="DATE"/>


### PR DESCRIPTION
The mapping for the `expired` column of `guacamole_user` is missing in the read direction for MySQL. For reference, see the corresponding PostgreSQL mapping:

https://github.com/apache/incubator-guacamole-client/blob/b90a98946359c9b0b7e4af8571034961d47322fa/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/user/UserMapper.xml#L26-L44

The column is queried in each `SELECT`. The value is simply dropped upon being queried due to that part of the result being unmapped, leaving the `expired` property of each user at the initial value of `false`.