### PR TITLE
GUACAMOLE-393: Add extension logout/shutdown hooks

### DIFF
--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/CASAuthenticationProvider.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/CASAuthenticationProvider.java
@@ -107,4 +107,9 @@ public class CASAuthenticationProvider implements AuthenticationProvider {
 
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }

--- a/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
+++ b/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
@@ -102,4 +102,9 @@ public class DuoAuthenticationProvider implements AuthenticationProvider {
         return context;
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }

--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
@@ -107,4 +107,9 @@ public class HTTPHeaderAuthenticationProvider implements AuthenticationProvider 
 
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
@@ -104,4 +104,9 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
                 authenticatedUser, credentials);
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
@@ -204,4 +204,9 @@ public class SharedUserContext implements UserContext {
         return Collections.<Form>emptyList();
     }
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -191,4 +191,9 @@ public class ModeledUserContext extends RestrictedObject
         return ModeledSharingProfile.ATTRIBUTES;
     }
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -136,4 +136,9 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
         return authenticationProvider;
     }
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
@@ -103,5 +103,10 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
         return context;
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
@@ -229,4 +229,9 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
         return Collections.<Form>emptyList();
     }
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -29,4 +29,9 @@ public abstract class AbstractAuthenticatedUser extends AbstractIdentifiable
 
     // Prior functionality now resides within AbstractIdentifiable
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
@@ -49,4 +49,11 @@ public interface AuthenticatedUser extends Identifiable {
      */
     Credentials getCredentials();
 
+    /**
+     * Invalidates this authenticated user and their associated token such that
+     * they are no longer logged in. This function will be automatically
+     * invoked when the user logs out, or when their session expires.
+     */
+    void invalidate();
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticationProvider.java
@@ -167,5 +167,12 @@ public interface AuthenticationProvider {
     UserContext updateUserContext(UserContext context,
             AuthenticatedUser authenticatedUser,
             Credentials credentials) throws GuacamoleException;
+
+    /**
+     * Frees all resources associated with this AuthenticationProvider. This
+     * function will be automatically invoked when the Guacamole server is
+     * shutting down.
+     */
+    void shutdown();
     
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -212,4 +212,11 @@ public interface UserContext {
      */
     Collection<Form> getSharingProfileAttributes();
 
+    /**
+     * Invalidates this user context, releasing all associated resources. This
+     * function will be invoked when the user logs out, or when their session
+     * is automatically invalidated.
+     */
+    void invalidate();
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -260,4 +260,9 @@ public abstract class SimpleAuthenticationProvider
         
     }
 
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
@@ -234,4 +234,9 @@ public class SimpleUserContext implements UserContext {
         return Collections.<Form>emptyList();
     }
 
+    @Override
+    public void invalidate() {
+        // Nothing to invalidate
+    }
+
 }

--- a/guacamole/src/main/java/org/apache/guacamole/GuacamoleSession.java
+++ b/guacamole/src/main/java/org/apache/guacamole/GuacamoleSession.java
@@ -252,6 +252,9 @@ public class GuacamoleSession {
             }
         }
 
+        // Invalidate the authenticated user object
+        authenticatedUser.invalidate();
+
     }
     
 }

--- a/guacamole/src/main/java/org/apache/guacamole/GuacamoleSession.java
+++ b/guacamole/src/main/java/org/apache/guacamole/GuacamoleSession.java
@@ -252,6 +252,10 @@ public class GuacamoleSession {
             }
         }
 
+        // Invalidate all user contextx
+        for (UserContext userContext : userContexts)
+            userContext.invalidate();
+
         // Invalidate the authenticated user object
         authenticatedUser.invalidate();
 

--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -209,4 +209,10 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
         
     }
 
+    @Override
+    public void shutdown() {
+        if (authProvider != null)
+            authProvider.shutdown();
+    }
+
 }


### PR DESCRIPTION
This change modifies the Guacamole extension API, adding the following additional hooks:

Class / Interface        | Function       | Description
------------------------ | -------------- | -----------
`AuthenticationProvider` | `shutdown()`   | The web application is being shut down, and the `AuthenticationProvider` should clean up any resources which will not be automatically freed.
`AuthenticatedUser`      | `invalidate()` | The user associated with the `AuthenticatedUser` is logging out, or their session has been automatically invalidated.
`UserContext`            | `invalidate()` | The user associated with the `UserContext` is logging out, or their session has been automatically invalidated.

Existing extensions have been updated accordingly.