### PR TITLE
GUACAMOLE-341: Automatically pull GUAC_USERNAME token from AuthenticatedUser.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -235,7 +235,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
 
         // Build token filter containing credential tokens
         TokenFilter tokenFilter = new TokenFilter();
-        StandardTokens.addStandardTokens(tokenFilter, user.getCredentials());
+        StandardTokens.addStandardTokens(tokenFilter, user);
 
         // Filter the configuration
         tokenFilter.filterValues(config.getParameters());
@@ -281,7 +281,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
 
         // Build token filter containing credential tokens
         TokenFilter tokenFilter = new TokenFilter();
-        StandardTokens.addStandardTokens(tokenFilter, user.getCredentials());
+        StandardTokens.addStandardTokens(tokenFilter, user);
 
         // Filter the configuration
         tokenFilter.filterValues(config.getParameters());

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -123,7 +123,7 @@ public class ConnectionService {
 
             // Build token filter containing credential tokens
             TokenFilter tokenFilter = new TokenFilter();
-            StandardTokens.addStandardTokens(tokenFilter, user.getCredentials());
+            StandardTokens.addStandardTokens(tokenFilter, user);
 
             // Produce connections for each readable configuration
             Map<String, Connection> connections = new HashMap<String, Connection>();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.token;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 
 /**
@@ -135,6 +136,33 @@ public class StandardTokens {
 
         // Add any tokens which do not require credentials
         addStandardTokens(filter);
+
+    }
+
+    /**
+     * Adds tokens which are standardized by guacamole-ext to the given
+     * TokenFilter using the values from the given AuthenticatedUser object,
+     * including any associated credentials. These standardized tokens include
+     * the current username (GUAC_USERNAME), password (GUAC_PASSWORD), and the
+     * server date and time (GUAC_DATE and GUAC_TIME respectively). If either
+     * the username or password are not set within the given user or their
+     * provided credentials, the corresponding token(s) will remain unset.
+     *
+     * @param filter
+     *     The TokenFilter to add standard tokens to.
+     *
+     * @param user
+     *     The AuthenticatedUser to use when populating the GUAC_USERNAME and
+     *     GUAC_PASSWORD tokens.
+     */
+    public static void addStandardTokens(TokenFilter filter, AuthenticatedUser user) {
+
+        // Default to the authenticated user's username for the GUAC_USERNAME
+        // token
+        filter.setToken(USERNAME_TOKEN, user.getIdentifier());
+
+        // Add tokens specific to credentials
+        addStandardTokens(filter, user.getCredentials());
 
     }
 


### PR DESCRIPTION
This change is meant to take the place of the spot fix implemented by #174, automatically pulling the "GUAC_USERNAME" token from the identifier of the `AuthenticatedUser` object if the associated `Credentials` to not have an explicit username set.