### PR TITLE
GUACAMOLE-412: Prevent exception propagation for null UserContext

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticatedUserEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticatedUserEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+
+/**
+ * Abstract basis for events which may have an Authenticateduser when
+ * triggered.
+ */
+public interface AuthenticatedUserEvent {
+
+    /**
+     * Returns the authenticated user of the triggering the event, if any.
+     *
+     * @return The authenticated user of the triggering the event, if any,
+     *      or null if no authenticated user are associated with the event.
+     */
+    AuthenticatedUser getAuthenticatedUser();
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationProviderEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationProviderEvent.java
@@ -19,34 +19,20 @@
 
 package org.apache.guacamole.net.event;
 
-import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
 
 /**
- * An event which is triggered whenever a user's credentials fail to be
- * authenticated. The credentials that failed to be authenticated are included
- * within this event, and can be retrieved using getCredentials().
+ * Abstract basis for events which have an authentication provider when
+ * triggered.
  */
-public class AuthenticationFailureEvent implements CredentialEvent {
+public interface AuthenticationProviderEvent {
 
     /**
-     * The credentials which failed authentication.
-     */
-    private Credentials credentials;
-
-    /**
-     * Creates a new AuthenticationFailureEvent which represents the failure
-     * to authenticate the given credentials.
+     * Returns the authentication provider associated with the event.
      *
-     * @param credentials
-     *     The credentials which failed authentication.
+     * @return The authentication provider object associated with the event, if
+     *         any, or null if no provider is associated with the event.
      */
-    public AuthenticationFailureEvent(Credentials credentials) {
-        this.credentials = credentials;
-    }
-
-    @Override
-    public Credentials getCredentials() {
-        return credentials;
-    }
+    AuthenticationProvider getAuthenticationProvider();
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.event;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 
@@ -32,7 +33,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * is effectively <em>vetoed</em> and will be subsequently processed as though the
  * authentication failed.
  */
-public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent {
+public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent, AuthenticatedUserEvent {
 
     /**
      * The UserContext associated with the request that is connecting the
@@ -43,7 +44,7 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent {
     /**
      * The credentials which passed authentication.
      */
-    private Credentials credentials;
+    private AuthenticatedUser authenticatedUser;
 
     /**
      * Creates a new AuthenticationSuccessEvent which represents a successful
@@ -51,11 +52,11 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent {
      *
      * @param context The UserContext created as a result of successful
      *                authentication.
-     * @param credentials The credentials which passed authentication.
+     * @param authenticatedUser The user which passed authentication.
      */
-    public AuthenticationSuccessEvent(UserContext context, Credentials credentials) {
+    public AuthenticationSuccessEvent(UserContext context, AuthenticatedUser authenticatedUser) {
         this.context = context;
-        this.credentials = credentials;
+        this.authenticatedUser = authenticatedUser;
     }
 
     @Override
@@ -65,7 +66,14 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent {
 
     @Override
     public Credentials getCredentials() {
-        return credentials;
+        if (authenticatedUser == null)
+            return null;
+        else
+            return authenticatedUser.getCredentials();
+    }
+
+    public AuthenticatedUser getAuthenticatedUser() {
+        return authenticatedUser;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.net.event;
 
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
@@ -33,13 +35,8 @@ import org.apache.guacamole.net.auth.UserContext;
  * is effectively <em>vetoed</em> and will be subsequently processed as though the
  * authentication failed.
  */
-public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent, AuthenticatedUserEvent {
-
-    /**
-     * The UserContext associated with the request that is connecting the
-     * tunnel, if any.
-     */
-    private UserContext context;
+public class AuthenticationSuccessEvent implements
+        UserEvent, CredentialEvent, AuthenticatedUserEvent, AuthenticationProviderEvent {
 
     /**
      * The credentials which passed authentication.
@@ -50,30 +47,36 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent, A
      * Creates a new AuthenticationSuccessEvent which represents a successful
      * authentication attempt with the given credentials.
      *
-     * @param context The UserContext created as a result of successful
-     *                authentication.
      * @param authenticatedUser The user which passed authentication.
      */
-    public AuthenticationSuccessEvent(UserContext context, AuthenticatedUser authenticatedUser) {
-        this.context = context;
+    public AuthenticationSuccessEvent(AuthenticatedUser authenticatedUser) {
         this.authenticatedUser = authenticatedUser;
     }
 
     @Override
-    public UserContext getUserContext() {
-        return context;
+    public UserContext getUserContext() throws GuacamoleException {
+        if (authenticatedUser == null)
+            return null;
+        return authenticatedUser.getAuthenticationProvider().getUserContext(authenticatedUser);
     }
 
     @Override
     public Credentials getCredentials() {
         if (authenticatedUser == null)
             return null;
-        else
-            return authenticatedUser.getCredentials();
+        return authenticatedUser.getCredentials();
     }
 
+    @Override
     public AuthenticatedUser getAuthenticatedUser() {
         return authenticatedUser;
+    }
+
+    @Override
+    public AuthenticationProvider getAuthenticationProvider() {
+        if (authenticatedUser == null)
+            return null;
+        return authenticatedUser.getAuthenticationProvider();
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserEvent.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.event;
 
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.UserContext;
 
 /**
@@ -32,7 +33,10 @@ public interface UserEvent {
      *
      * @return The current UserContext of the user triggering the event, if
      *         any, or null if no UserContext is associated with the event.
+     *
+     * @throws GuacamoleException
+     *     If the UserContext object cannot be retrieved.
      */
-    UserContext getUserContext();
+    UserContext getUserContext() throws GuacamoleException;
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -235,20 +235,8 @@ public class AuthenticationService {
             AuthenticatedUser authenticatedUser, GuacamoleSession session)
             throws GuacamoleException {
 
-        UserContext userContext = null;
-        if (session != null) {
-            try {
-                userContext = session.getUserContext(
-                    authenticatedUser.getAuthenticationProvider().getIdentifier());
-            }
-            catch (GuacamoleResourceNotFoundException e) {
-                logger.warn("Resource not found when getting user context.");
-                logger.debug("Received exception when getting user context.", e);
-            }
-        }
-
         listenerService.handleEvent(new AuthenticationSuccessEvent(
-            userContext, authenticatedUser));
+            authenticatedUser));
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.GuacamoleUnauthorizedException;
 import org.apache.guacamole.GuacamoleSession;

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.GuacamoleUnauthorizedException;
 import org.apache.guacamole.GuacamoleSession;
@@ -236,8 +237,14 @@ public class AuthenticationService {
 
         UserContext userContext = null;
         if (session != null) {
-            userContext = session.getUserContext(
-                authenticatedUser.getAuthenticationProvider().getIdentifier());
+            try {
+                userContext = session.getUserContext(
+                    authenticatedUser.getAuthenticationProvider().getIdentifier());
+            }
+            catch (GuacamoleResourceNotFoundException e) {
+                logger.warn("Resource not found when getting user context.");
+                logger.debug("Received exception when getting user context.", e);
+            }
         }
 
         listenerService.handleEvent(new AuthenticationSuccessEvent(

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -248,7 +248,7 @@ public class AuthenticationService {
         }
 
         listenerService.handleEvent(new AuthenticationSuccessEvent(
-            userContext, authenticatedUser.getCredentials()));
+            userContext, authenticatedUser));
     }
 
     /**


### PR DESCRIPTION
Changes to event listeners from GUACAMOLE-364 (#184) cause modules that do not have a UserContext object to fail at login.  This is a potential fix for that issue - preventing the GuacamoleResourceNotFoundException from propagating down and instead just throwing a warning and debug message into the log file.  Not sure if this is the preferred way to go, or if there are other implications to this?