### PR TITLE
GUACAMOLE-416: Add translation entries for SQL Server module.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -63,6 +63,14 @@
         "NAME" : "Shared Connections (PostgreSQL)"
     },
 
+    "DATA_SOURCE_SQLSERVER" : {
+        "NAME" : "SQL Server"
+    },
+
+    "DATA_SOURCe_SQLSERVER_SHARED" : {
+        "NAME" : "Shared Connections (SQL Server)"
+    },
+
     "HOME" : {
         "INFO_SHARED_BY" : "Shared by {USERNAME}"
     },


### PR DESCRIPTION
Minor tweak to add missing entries for the SQL Server module to the base jdbc en.json file.