### PR TITLE
GUACAMOLE-243: Ignore LDAPReferralExceptions when processing search results

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -124,7 +124,8 @@ public class UserService {
 
                 }
                 catch (LDAPReferralException e) {
-                    logger.warn("Ignoring LDAP Referral while querying users.");
+                    logger.warn("Ignoring LDAP Referral while querying users on referral: \"{}\"", e.getFailedReferral());
+                    logger.debug("Received exception when trying to follow LDAP referral", e);
                 }
             }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -24,6 +24,7 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPReferralException;
 import com.novell.ldap.LDAPSearchResults;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -106,21 +107,24 @@ public class UserService {
 
             // Read all visible users
             while (results.hasMore()) {
+                try {
+                    LDAPEntry entry = results.next();
 
-                LDAPEntry entry = results.next();
+                    // Get username from record
+                    LDAPAttribute username = entry.getAttribute(usernameAttribute);
+                    if (username == null) {
+                        logger.warn("Queried user is missing the username attribute \"{}\".", usernameAttribute);
+                        continue;
+                    }
 
-                // Get username from record
-                LDAPAttribute username = entry.getAttribute(usernameAttribute);
-                if (username == null) {
-                    logger.warn("Queried user is missing the username attribute \"{}\".", usernameAttribute);
-                    continue;
+                    // Store user using their username as the identifier
+                    String identifier = username.getStringValue();
+                    if (users.put(identifier, new SimpleUser(identifier)) != null)
+                        logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
+
+                } catch (LDAPReferralException e) {
+                    logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
                 }
-
-                // Store user using their username as the identifier
-                String identifier = username.getStringValue();
-                if (users.put(identifier, new SimpleUser(identifier)) != null)
-                    logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
-
             }
 
         }
@@ -267,8 +271,13 @@ public class UserService {
 
             // Add all DNs for found users
             while (results.hasMore()) {
-                LDAPEntry entry = results.next();
-                userDNs.add(entry.getDN());
+                try {
+                    LDAPEntry entry = results.next();
+                    userDNs.add(entry.getDN());
+                } catch (LDAPReferralException e) {
+                    logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
+
+                }
             }
 
             // Return all discovered DNs (if any)

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -122,7 +122,8 @@ public class UserService {
                     if (users.put(identifier, new SimpleUser(identifier)) != null)
                         logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
 
-                } catch (LDAPReferralException e) {
+                }
+                catch (LDAPReferralException e) {
                     logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
                 }
             }
@@ -274,9 +275,9 @@ public class UserService {
                 try {
                     LDAPEntry entry = results.next();
                     userDNs.add(entry.getDN());
-                } catch (LDAPReferralException e) {
+                }
+                catch (LDAPReferralException e) {
                     logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
-
                 }
             }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
 
                 }
                 catch (LDAPReferralException e) {
-                    logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
+                    logger.warn("Ignoring LDAP Referral while querying users.");
                 }
             }
 
@@ -277,7 +277,7 @@ public class UserService {
                     userDNs.add(entry.getDN());
                 }
                 catch (LDAPReferralException e) {
-                    logger.debug("Ignoring LDAP Referral: \"{}\".", e.toString());
+                    logger.warn("Ignoring LDAP Referral while querying user DNs.");
                 }
             }
 


### PR DESCRIPTION
This pull request finishes up the code that @alt36 started for fixing issues with LDAP Referrals.

This closes #129.