### PR TITLE
GUACAMOLE-416: Fix typo in translation file

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -67,7 +67,7 @@
         "NAME" : "SQL Server"
     },
 
-    "DATA_SOURCe_SQLSERVER_SHARED" : {
+    "DATA_SOURCE_SQLSERVER_SHARED" : {
         "NAME" : "Shared Connections (SQL Server)"
     },
 


### PR DESCRIPTION
Fix a typo that @mike-jumper caught in the translation file after the last commit.