### PR TITLE
GUACAMOLE-243: Allow LDAP referral following to be configured

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -257,7 +257,7 @@ public class ConfigurationService {
      *
      * @return
      *     The boolean value of whether to follow referrals
-     *     as configured in guacamole.properties
+     *     as configured in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
@@ -295,7 +295,7 @@ public class ConfigurationService {
      *
      * @return
      *     The maximum number of referral hops to follow
-     *     as configured in guacamole.properties
+     *     as configured in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
@@ -328,11 +328,11 @@ public class ConfigurationService {
     }
 
     /**
-     * Returns the maximum number of seconds to wait for LDAP operations
+     * Returns the maximum number of seconds to wait for LDAP operations.
      *
      * @return
      *     The maximum number of seconds to wait for LDAP operations
-     *     as configured in guacamole.properties
+     *     as configured in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -316,6 +316,7 @@ public class ConfigurationService {
      *     The search filter that should be used when querying the
      *     LDAP server for users that are valid in Guacamole, or
      *     "(objectClass=*)" if not specified.
+     *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
@@ -324,37 +325,6 @@ public class ConfigurationService {
             LDAPGuacamoleProperties.LDAP_USER_SEARCH_FILTER,
             "(objectClass=*)"
         );
-    }
-
-    /**
-     * Returns the authentication method to use during referral following.
-     *
-     * @return
-     *     The authentication method to use during referral following
-     *     as configured in guacamole.properties or as derived from
-     *     other configuration options.
-     *
-     * @throws GuacamoleException
-     *     If guacamole.properties cannot be parsed.
-     */
-    public String getReferralAuthentication() throws GuacamoleException {
-        String confMethod = environment.getProperty(
-            LDAPGuacamoleProperties.LDAP_REFERRAL_AUTHENTICATION
-        );
-
-        if (confMethod == null)
-
-            if (getSearchBindDN() != null && getSearchBindPassword() != null)
-                return "bind";
-
-            else
-                return "anonymous";
-
-        else if (confMethod.equals("bind") && (getSearchBindDN() == null || getSearchBindPassword() == null))
-            throw new GuacamoleException("Referral is set to bind with credentials, but credentials are not configured.");
-
-        return confMethod;
-
     }
 
     /**

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -252,6 +252,24 @@ public class ConfigurationService {
     }
 
     /**
+     * Returns the boolean value for whether the connection should
+     * follow referrals or not.  By default, it will not.
+     *
+     * @return
+     *     The boolean value of whether to follow referrals
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public boolean getFollowReferrals() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_FOLLOW_REFERRALS,
+            false
+        );
+    }
+
+    /**
      * Returns a set of LDAPSearchConstraints to apply globally
      * to all LDAP searches.
      *
@@ -273,6 +291,23 @@ public class ConfigurationService {
     }
 
     /**
+     * Returns the maximum number of referral hops to follow.
+     *
+     * @return
+     *     The maximum number of referral hops to follow
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getMaxReferralHops() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_MAX_REFERRAL_HOPS,
+            5
+        );
+    }
+
+    /**
      * Returns the search filter that should be used when querying the
      * LDAP server for Guacamole users.  If no filter is specified,
      * a default of "(objectClass=*)" is returned.
@@ -281,7 +316,6 @@ public class ConfigurationService {
      *     The search filter that should be used when querying the
      *     LDAP server for users that are valid in Guacamole, or
      *     "(objectClass=*)" if not specified.
-     *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
@@ -289,6 +323,54 @@ public class ConfigurationService {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_USER_SEARCH_FILTER,
             "(objectClass=*)"
+        );
+    }
+
+    /**
+     * Returns the authentication method to use during referral following.
+     *
+     * @return
+     *     The authentication method to use during referral following
+     *     as configured in guacamole.properties or as derived from
+     *     other configuration options.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getReferralAuthentication() throws GuacamoleException {
+        String confMethod = environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_REFERRAL_AUTHENTICATION
+        );
+
+        if (confMethod == null)
+
+            if (getSearchBindDN() != null && getSearchBindPassword() != null)
+                return "bind";
+
+            else
+                return "anonymous";
+
+        else if (confMethod.equals("bind") && (getSearchBindDN() == null || getSearchBindPassword() == null))
+            throw new GuacamoleException("Referral is set to bind with credentials, but credentials are not configured.");
+
+        return confMethod;
+
+    }
+
+    /**
+     * Returns the maximum number of seconds to wait for LDAP operations
+     *
+     * @return
+     *     The maximum number of seconds to wait for LDAP operations
+     *     as configured in guacamole.properties
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public int getOperationTimeout() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_OPERATION_TIMEOUT,
+            30
         );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -123,8 +123,7 @@ public class LDAPConnectionService {
 
         // If the referral auth method is set to bind, we set it using the existing
         // username and password.
-        String refAuthMethod = confService.getReferralAuthentication();
-        if (refAuthMethod != null && refAuthMethod.equals("bind"))
+        if (userDN != null && !userDN.isEmpty())
             ldapConstraints.setReferralHandler(new ReferralAuthHandler(userDN, password));
 
         // Set the maximum number of referrals we follow

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -118,13 +118,16 @@ public class LDAPConnectionService {
         if (ldapConstraints == null)
           ldapConstraints = new LDAPConstraints();
 
-        // Set whether or not we follow referrals, and max hops
+        // Set whether or not we follow referrals
         ldapConstraints.setReferralFollowing(confService.getFollowReferrals());
-        String refAuthMethod = confService.getReferralAuthentication();
 
+        // If the referral auth method is set to bind, we set it using the existing
+        // username and password.
+        String refAuthMethod = confService.getReferralAuthentication();
         if (refAuthMethod != null && refAuthMethod.equals("bind"))
             ldapConstraints.setReferralHandler(new ReferralAuthHandler(userDN, password));
 
+        // Set the maximum number of referrals we follow
         ldapConstraints.setHopLimit(confService.getMaxReferralHops());
 
         // Set timelimit to wait for LDAP operations, converting to ms

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -121,8 +121,7 @@ public class LDAPConnectionService {
         // Set whether or not we follow referrals
         ldapConstraints.setReferralFollowing(confService.getFollowReferrals());
 
-        // If the referral auth method is set to bind, we set it using the existing
-        // username and password.
+        // Set referral authentication to use the provided credentials.
         if (userDN != null && !userDN.isEmpty())
             ldapConstraints.setReferralHandler(new ReferralAuthHandler(userDN, password));
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.auth.ldap;
 
+import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 
@@ -171,6 +172,46 @@ public class LDAPGuacamoleProperties {
 
         @Override
         public String getName() { return "ldap-user-search-filter"; }
+
+    };
+
+    /**
+     * Whether or not we should follow referrals
+     */
+    public static final BooleanGuacamoleProperty LDAP_FOLLOW_REFERRALS = new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-follow-referrals"; }
+
+    };
+
+    /**
+     * Maximum number of referral hops to follow
+     */
+    public static final IntegerGuacamoleProperty LDAP_MAX_REFERRAL_HOPS = new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-max-referral-hops"; }
+
+    };
+
+    /**
+     * Authentication method to use to follow referrals
+     */
+    public static final StringGuacamoleProperty LDAP_REFERRAL_AUTHENTICATION = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-referral-authentication"; }
+
+    };
+
+    /**
+     * Number of seconds to wait for LDAP operations to complete
+     */
+    public static final IntegerGuacamoleProperty LDAP_OPERATION_TIMEOUT = new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-operation-timeout"; }
 
     };
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -176,7 +176,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * Whether or not we should follow referrals
+     * Whether or not we should follow referrals.
      */
     public static final BooleanGuacamoleProperty LDAP_FOLLOW_REFERRALS = new BooleanGuacamoleProperty() {
 
@@ -186,7 +186,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * Maximum number of referral hops to follow
+     * Maximum number of referral hops to follow.
      */
     public static final IntegerGuacamoleProperty LDAP_MAX_REFERRAL_HOPS = new IntegerGuacamoleProperty() {
 
@@ -196,7 +196,7 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * Number of seconds to wait for LDAP operations to complete
+     * Number of seconds to wait for LDAP operations to complete.
      */
     public static final IntegerGuacamoleProperty LDAP_OPERATION_TIMEOUT = new IntegerGuacamoleProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -196,16 +196,6 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * Authentication method to use to follow referrals
-     */
-    public static final StringGuacamoleProperty LDAP_REFERRAL_AUTHENTICATION = new StringGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "ldap-referral-authentication"; }
-
-    };
-
-    /**
      * Number of seconds to wait for LDAP operations to complete
      */
     public static final IntegerGuacamoleProperty LDAP_OPERATION_TIMEOUT = new IntegerGuacamoleProperty() {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
@@ -48,12 +48,8 @@ public class ReferralAuthHandler implements LDAPAuthHandler {
      * Creates a ReferralAuthHandler object to handle authentication when
      * following referrals in a LDAP connection, using the provided dn and
      * password.
-     *
-     * @throws GuacamoleException
-     *     If exceptions are caught while converting the password from a string
-     *     into a byte array.
      */
-    public ReferralAuthHandler(String dn, String password) throws GuacamoleException {
+    public ReferralAuthHandler(String dn, String password) {
         byte[] passwordBytes;
         try {
 
@@ -67,7 +63,7 @@ public class ReferralAuthHandler implements LDAPAuthHandler {
         catch (UnsupportedEncodingException e) {
             logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
             logger.debug("Support for UTF-8 (as required by Java spec) not found.", e); 
-            throw new GuacamoleException("Could not set password due to missing UTF-8 support.");
+            throw new UnsupportedOperationException("Unexpected lack of UTF-8 support.", e);
         }
         ldapAuth = new LDAPAuthProvider(dn, passwordBytes);
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap;
+
+import com.google.inject.Inject;
+import com.novell.ldap.LDAPAuthHandler;
+import com.novell.ldap.LDAPAuthProvider;
+import com.novell.ldap.LDAPConnection;
+import java.io.UnsupportedEncodingException;
+import org.apache.guacamole.GuacamoleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReferralAuthHandler implements LDAPAuthHandler {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ReferralAuthHandler.class);
+
+    /**
+     * The LDAPAuthProvider object that will be set and returned to the referral handler.
+     */
+    private final LDAPAuthProvider ldapAuth;
+
+    /**
+     * Service for retrieving LDAP server configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
+
+
+    public ReferralAuthHandler() throws GuacamoleException {
+        String binddn = confService.getSearchBindDN();
+        String password = confService.getSearchBindPassword();
+        byte[] passwordBytes;
+        try {
+
+            // Convert password into corresponding byte array
+            if (password != null)
+                passwordBytes = password.getBytes("UTF-8");
+            else
+                passwordBytes = null;
+
+        }
+        catch (UnsupportedEncodingException e) {
+            logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
+            logger.debug("Support for UTF-8 (as required by Java spec) not found.", e);
+            throw new GuacamoleException("Could not set password due to missing support for UTF-8 encoding.");
+        }
+
+        ldapAuth = new LDAPAuthProvider(binddn, passwordBytes);
+
+    }
+
+    public ReferralAuthHandler(String dn, String password) throws GuacamoleException {
+        byte[] passwordBytes;
+        try {
+
+            // Convert password into corresponding byte array
+            if (password != null)
+                passwordBytes = password.getBytes("UTF-8");
+            else
+                passwordBytes = null;
+
+        }   
+        catch (UnsupportedEncodingException e) {
+            logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
+            logger.debug("Support for UTF-8 (as required by Java spec) not found.", e); 
+            throw new GuacamoleException("Could not set password due to missing UTF-8 support.");
+        }
+        ldapAuth = new LDAPAuthProvider(dn, passwordBytes);
+    }
+
+    @Override
+    public LDAPAuthProvider getAuthProvider(String host, int port) {
+        return ldapAuth;
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ReferralAuthHandler.java
@@ -28,6 +28,10 @@ import org.apache.guacamole.GuacamoleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Class that implements the necessary authentication handling
+ * for following referrals in LDAP connections.
+ */
 public class ReferralAuthHandler implements LDAPAuthHandler {
 
     /**
@@ -41,35 +45,14 @@ public class ReferralAuthHandler implements LDAPAuthHandler {
     private final LDAPAuthProvider ldapAuth;
 
     /**
-     * Service for retrieving LDAP server configuration information.
+     * Creates a ReferralAuthHandler object to handle authentication when
+     * following referrals in a LDAP connection, using the provided dn and
+     * password.
+     *
+     * @throws GuacamoleException
+     *     If exceptions are caught while converting the password from a string
+     *     into a byte array.
      */
-    @Inject
-    private ConfigurationService confService;
-
-
-    public ReferralAuthHandler() throws GuacamoleException {
-        String binddn = confService.getSearchBindDN();
-        String password = confService.getSearchBindPassword();
-        byte[] passwordBytes;
-        try {
-
-            // Convert password into corresponding byte array
-            if (password != null)
-                passwordBytes = password.getBytes("UTF-8");
-            else
-                passwordBytes = null;
-
-        }
-        catch (UnsupportedEncodingException e) {
-            logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
-            logger.debug("Support for UTF-8 (as required by Java spec) not found.", e);
-            throw new GuacamoleException("Could not set password due to missing support for UTF-8 encoding.");
-        }
-
-        ldapAuth = new LDAPAuthProvider(binddn, passwordBytes);
-
-    }
-
     public ReferralAuthHandler(String dn, String password) throws GuacamoleException {
         byte[] passwordBytes;
         try {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -277,14 +277,13 @@ public class ConnectionService {
 
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.error("Could not follow referral: {}", e.getFailedReferral());
                         logger.debug("Error encountered trying to follow referral.", e);
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
                         logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
-                        continue;
                     }
                 }
             }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -194,7 +194,7 @@ public class ConnectionService {
                 // Deal with issues following LDAP referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.error("Could not follow referral.", e.getFailedReferral());
                         logger.debug("Error encountered trying to follow referral.", e);
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -201,7 +201,6 @@ public class ConnectionService {
                     else {
                         logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
-                        continue;
                     }
                 }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -194,12 +194,12 @@ public class ConnectionService {
                 // Deal with issues following LDAP referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral.", e.getFailedReferral());
+                        logger.error("Could not follow referral: {}", e.getFailedReferral());
                         logger.debug("Error encountered trying to follow referral.", e);
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
-                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.warn("Given a referral, but referrals are disabled. Error was: {}", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
                     }
                 }
@@ -281,7 +281,7 @@ public class ConnectionService {
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
-                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.warn("Given a referral, but referrals are disabled. Error was: {}", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
                     }
                 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -125,15 +125,17 @@ public class UserService {
                         logger.warn("Possibly ambiguous user account: \"{}\".", identifier);
 
                 }
+
+                // Deal with errors trying to follow referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
                         logger.error("Could not follow referral.", e.getMessage());
                         logger.debug("Error encountered trying to follow referral.", e);
-                        throw new GuacamoleException("Could not follow LDAP referral.");
+                        throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
-                        logger.warn("Encountered a referral, but not following it.", e.getMessage());
-                        logger.debug("Got a referral, but not configured to follow it.", e);
+                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.debug("Got a referral, but configured to not follow them.", e);
                         continue;
                     }
                 }
@@ -284,8 +286,24 @@ public class UserService {
 
             // Add all DNs for found users
             while (results.hasMore()) {
-                LDAPEntry entry = results.next();
-                userDNs.add(entry.getDN());
+                try {
+                    LDAPEntry entry = results.next();
+                    userDNs.add(entry.getDN());
+                }
+          
+                // Deal with errors following referrals
+                catch (LDAPReferralException e) {
+                    if (confService.getFollowReferrals()) {
+                        logger.error("Error trying to follow a referral.", e.getMessage());
+                        logger.debug("Encountered an error trying to follow a referral.", e);
+                        throw new GuacamoleServerException("Failed while trying to follow referrals.", e);
+                    }
+                    else {
+                        logger.warn("Given a referral, not following it.", e.getMessage());
+                        logger.debug("Given a referral, but configured to not follow them.", e);
+                        continue;
+                    }
+                }
             }
 
             // Return all discovered DNs (if any)

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -129,7 +129,7 @@ public class UserService {
                 // Deal with errors trying to follow referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral.", e.getMessage());
+                        logger.error("Could not follow referral.", e.getFailedReferral());
                         logger.debug("Error encountered trying to follow referral.", e);
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -300,7 +300,6 @@ public class UserService {
                     else {
                         logger.warn("Given a referral, not following it.", e.getMessage());
                         logger.debug("Given a referral, but configured to not follow them.", e);
-                        continue;
                     }
                 }
             }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -134,7 +134,7 @@ public class UserService {
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
-                        logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
+                        logger.warn("Given a referral, but referrals are disabled. Error was: {}", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
                     }
                 }
@@ -293,12 +293,12 @@ public class UserService {
                 // Deal with errors following referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Error trying to follow a referral.", e.getMessage());
+                        logger.error("Error trying to follow a referral: {}", e.getFailedReferral());
                         logger.debug("Encountered an error trying to follow a referral.", e);
                         throw new GuacamoleServerException("Failed while trying to follow referrals.", e);
                     }
                     else {
-                        logger.warn("Given a referral, not following it.", e.getMessage());
+                        logger.warn("Given a referral, not following it. Error was: {}", e.getMessage());
                         logger.debug("Given a referral, but configured to not follow them.", e);
                     }
                 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -129,14 +129,13 @@ public class UserService {
                 // Deal with errors trying to follow referrals
                 catch (LDAPReferralException e) {
                     if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral.", e.getFailedReferral());
+                        logger.error("Could not follow referral: {}", e.getFailedReferral());
                         logger.debug("Error encountered trying to follow referral.", e);
                         throw new GuacamoleServerException("Could not follow LDAP referral.", e);
                     }
                     else {
                         logger.warn("Given a referral, but referrals are disabled.", e.getMessage());
                         logger.debug("Got a referral, but configured to not follow them.", e);
-                        continue;
                     }
                 }
 


### PR DESCRIPTION
This PR fixes the JIRA issue 243, where errors in following referrals block LDAP authentication from succeeding, by allowing referral support to be configured.

This closes #129.