### PR TITLE
GUACAMOLE-412: Refactor UserEvent to provide AuthenticatedUser instead of UserContext.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
@@ -19,8 +19,8 @@
 
 package org.apache.guacamole.net.event;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * An event which is triggered whenever a user's credentials pass
@@ -35,37 +35,32 @@ import org.apache.guacamole.net.auth.UserContext;
 public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent {
 
     /**
-     * The UserContext associated with the request that is connecting the
-     * tunnel, if any.
+     * The AuthenticatedUser identifying the user that successfully
+     * authenticated.
      */
-    private UserContext context;
-
-    /**
-     * The credentials which passed authentication.
-     */
-    private Credentials credentials;
+    private final AuthenticatedUser authenticatedUser;
 
     /**
      * Creates a new AuthenticationSuccessEvent which represents a successful
-     * authentication attempt with the given credentials.
+     * authentication attempt by the user identified by the given
+     * AuthenticatedUser object.
      *
-     * @param context The UserContext created as a result of successful
-     *                authentication.
-     * @param credentials The credentials which passed authentication.
+     * @param authenticatedUser
+     *     The AuthenticatedUser identifying the user that successfully
+     *     authenticated.
      */
-    public AuthenticationSuccessEvent(UserContext context, Credentials credentials) {
-        this.context = context;
-        this.credentials = credentials;
+    public AuthenticationSuccessEvent(AuthenticatedUser authenticatedUser) {
+        this.authenticatedUser = authenticatedUser;
     }
 
     @Override
-    public UserContext getUserContext() {
-        return context;
+    public AuthenticatedUser getAuthenticatedUser() {
+        return authenticatedUser;
     }
 
     @Override
     public Credentials getCredentials() {
-        return credentials;
+        return authenticatedUser.getCredentials();
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/TunnelCloseEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/TunnelCloseEvent.java
@@ -20,8 +20,8 @@
 package org.apache.guacamole.net.event;
 
 import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * An event which is triggered whenever a tunnel is being closed. The tunnel
@@ -36,42 +36,48 @@ import org.apache.guacamole.net.auth.UserContext;
 public class TunnelCloseEvent implements UserEvent, CredentialEvent, TunnelEvent {
 
     /**
-     * The UserContext associated with the request that is closing the
+     * The AuthenticatedUser associated with the user that is closing the
      * tunnel, if any.
      */
-    private UserContext context;
+    private final AuthenticatedUser authenticatedUser;
 
     /**
-     * The credentials associated with the request that connected the
-     * tunnel, if any.
+     * The credentials associated with the request that closed the tunnel, if
+     * any.
      */
-    private Credentials credentials;
+    private final Credentials credentials;
 
     /**
      * The tunnel being closed.
      */
-    private GuacamoleTunnel tunnel;
+    private final GuacamoleTunnel tunnel;
 
     /**
      * Creates a new TunnelCloseEvent which represents the closing of the
      * given tunnel via a request associated with the given credentials.
      *
-     * @param context The UserContext associated with the request closing 
-     *                the tunnel.
-     * @param credentials The credentials associated with the request that 
-     *                    connected the tunnel.
-     * @param tunnel The tunnel being closed.
+     * @param authenticatedUser
+     *     The AuthenticatedUser associated with the user that is closing the
+     *     tunnel, if any.
+     *
+     * @param credentials
+     *     The credentials associated with the request that closed the
+     *     tunnel. Note that these credentials are not necessarily the same as
+     *     the credentials provided when the user authenticated.
+     *
+     * @param tunnel
+     *     The tunnel being closed.
      */
-    public TunnelCloseEvent(UserContext context, Credentials credentials,
-            GuacamoleTunnel tunnel) {
-        this.context = context;
+    public TunnelCloseEvent(AuthenticatedUser authenticatedUser,
+            Credentials credentials, GuacamoleTunnel tunnel) {
+        this.authenticatedUser = authenticatedUser;
         this.credentials = credentials;
         this.tunnel = tunnel;
     }
 
     @Override
-    public UserContext getUserContext() {
-        return context;
+    public AuthenticatedUser getAuthenticatedUser() {
+        return authenticatedUser;
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/TunnelConnectEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/TunnelConnectEvent.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.net.event;
 
 import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 
@@ -36,42 +37,47 @@ import org.apache.guacamole.net.auth.UserContext;
 public class TunnelConnectEvent implements UserEvent, CredentialEvent, TunnelEvent {
 
     /**
-     * The UserContext associated with the request that is connecting the
+     * The AuthenticatedUser associated with the user that is connecting the
      * tunnel, if any.
      */
-    private UserContext context;
+    private final AuthenticatedUser authenticatedUser;
 
     /**
      * The credentials associated with the request that is connecting the
      * tunnel, if any.
      */
-    private Credentials credentials;
+    private final Credentials credentials;
 
     /**
      * The tunnel being connected.
      */
-    private GuacamoleTunnel tunnel;
+    private final GuacamoleTunnel tunnel;
 
     /**
      * Creates a new TunnelConnectEvent which represents the connecting of the
      * given tunnel via a request associated with the given credentials.
      *
-     * @param context The UserContext associated with the request connecting
-     *                the tunnel.
-     * @param credentials The credentials associated with the request connecting
-     *                    the tunnel.
+     * @param authenticatedUser
+     *     The AuthenticatedUser associated with the user that is connecting the
+     *     tunnel, if any.
+     *
+     * @param credentials
+     *     The credentials associated with the request that connected the
+     *     tunnel. Note that these credentials are not necessarily the same as
+     *     the credentials provided when the user authenticated.
+     *
      * @param tunnel The tunnel being connected.
      */
-    public TunnelConnectEvent(UserContext context, Credentials credentials,
-            GuacamoleTunnel tunnel) {
-        this.context = context;
+    public TunnelConnectEvent(AuthenticatedUser authenticatedUser,
+            Credentials credentials, GuacamoleTunnel tunnel) {
+        this.authenticatedUser = authenticatedUser;
         this.credentials = credentials;
         this.tunnel = tunnel;
     }
 
     @Override
-    public UserContext getUserContext() {
-        return context;
+    public AuthenticatedUser getAuthenticatedUser() {
+        return authenticatedUser;
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserEvent.java
@@ -19,20 +19,22 @@
 
 package org.apache.guacamole.net.event;
 
-import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 
 /**
- * Abstract basis for events which may have an associated UserContext when
+ * Abstract basis for events which may have an associated AuthenticatedUser when
  * triggered.
  */
 public interface UserEvent {
 
     /**
-     * Returns the current UserContext of the user triggering the event, if any.
+     * Returns the AuthenticatedUser identifying the user triggering the event,
+     * if any.
      *
-     * @return The current UserContext of the user triggering the event, if
-     *         any, or null if no UserContext is associated with the event.
+     * @return
+     *     The AuthenticatedUser identifying the user triggering the event, if
+     *     any, or null if no AuthenticatedUser is associated with the event.
      */
-    UserContext getUserContext();
+    AuthenticatedUser getAuthenticatedUser();
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -224,24 +224,12 @@ public class AuthenticationService {
      * @param authenticatedUser
      *      The user that was successfully authenticated.
      *
-     * @param session
-     *      The existing session for the user (if any).
-     *
      * @throws GuacamoleException
      *      If thrown by a listener.
      */
-    private void fireAuthenticationSuccessEvent(
-            AuthenticatedUser authenticatedUser, GuacamoleSession session)
+    private void fireAuthenticationSuccessEvent(AuthenticatedUser authenticatedUser)
             throws GuacamoleException {
-
-        UserContext userContext = null;
-        if (session != null) {
-            userContext = session.getUserContext(
-                authenticatedUser.getAuthenticationProvider().getIdentifier());
-        }
-
-        listenerService.handleEvent(new AuthenticationSuccessEvent(
-            userContext, authenticatedUser.getCredentials()));
+        listenerService.handleEvent(new AuthenticationSuccessEvent(authenticatedUser));
     }
 
     /**
@@ -286,13 +274,13 @@ public class AuthenticationService {
             if (existingSession != null) {
                 AuthenticatedUser updatedUser = updateAuthenticatedUser(
                         existingSession.getAuthenticatedUser(), credentials);
-                fireAuthenticationSuccessEvent(updatedUser, existingSession);
+                fireAuthenticationSuccessEvent(updatedUser);
                 return updatedUser;
             }
 
             // Otherwise, attempt authentication as a new user
             AuthenticatedUser authenticatedUser = AuthenticationService.this.authenticateUser(credentials);
-            fireAuthenticationSuccessEvent(authenticatedUser, null);
+            fireAuthenticationSuccessEvent(authenticatedUser);
 
             if (logger.isInfoEnabled())
                 logger.info("User \"{}\" successfully authenticated from {}.",


### PR DESCRIPTION
This change refactors `UserEvent` and related classes, representing user identity with `AuthenticatedUser` rather than `UserContext`. The use of `UserContext` to represent identity was a holdover from the pre-0.9.8 days when auth was tied to storage, back before `AuthenticatedUser` existed.

This closes #197.