### PR TITLE
GUACAMOLE-431: Fix Tunnel handling of CLOSED state

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -55,6 +55,25 @@ Guacamole.Tunnel = function() {
     this.sendMessage = function(elements) {};
 
     /**
+     * Changes the stored numeric state of this tunnel, firing the onstatechange
+     * event if the new state is different and a handler has been defined.
+     *
+     * @private
+     * @param {Number} state
+     *     The new state of this tunnel.
+     */
+    this.setState = function(state) {
+
+        // Notify only if state changes
+        if (state !== this.state) {
+            this.state = state;
+            if (this.onstatechange)
+                this.onstatechange(state);
+        }
+
+    };
+
+    /**
      * The current state of this tunnel.
      * 
      * @type {Number}
@@ -239,14 +258,11 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain) {
 
         }
 
-        // Mark as closed
-        tunnel.state = Guacamole.Tunnel.State.CLOSED;
-
         // Reset output message buffer
         sendingMessages = false;
 
-        if (tunnel.onstatechange)
-            tunnel.onstatechange(tunnel.state);
+        // Mark as closed
+        tunnel.setState(Guacamole.Tunnel.State.CLOSED);
 
     }
 
@@ -566,9 +582,8 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain) {
             // Get UUID from response
             tunnel.uuid = connect_xmlhttprequest.responseText;
 
-            tunnel.state = Guacamole.Tunnel.State.OPEN;
-            if (tunnel.onstatechange)
-                tunnel.onstatechange(tunnel.state);
+            // Mark as open
+            tunnel.setState(Guacamole.Tunnel.State.OPEN);
 
             // Start reading data
             handleResponse(makeRequest());
@@ -698,9 +713,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
             tunnel.onerror(status);
 
         // Mark as closed
-        tunnel.state = Guacamole.Tunnel.State.CLOSED;
-        if (tunnel.onstatechange)
-            tunnel.onstatechange(tunnel.state);
+        tunnel.setState(Guacamole.Tunnel.State.CLOSED);
 
         socket.close();
 
@@ -814,9 +827,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
                             tunnel.uuid = elements[0];
 
                         // Tunnel is now open and UUID is available
-                        tunnel.state = Guacamole.Tunnel.State.OPEN;
-                        if (tunnel.onstatechange)
-                            tunnel.onstatechange(tunnel.state);
+                        tunnel.setState(Guacamole.Tunnel.State.OPEN);
 
                     }
 
@@ -1060,25 +1071,6 @@ Guacamole.StaticHTTPTunnel = function StaticHTTPTunnel(url, crossDomain) {
     var xhr = null;
 
     /**
-     * Changes the stored numeric state of this tunnel, firing the onstatechange
-     * event if the new state is different and a handler has been defined.
-     *
-     * @private
-     * @param {Number} state
-     *     The new state of this tunnel.
-     */
-    var setState = function setState(state) {
-
-        // Notify only if state changes
-        if (state !== tunnel.state) {
-            tunnel.state = state;
-            if (tunnel.onstatechange)
-                tunnel.onstatechange(state);
-        }
-
-    };
-
-    /**
      * Returns the Guacamole protocol status code which most closely
      * represents the given HTTP status code.
      *
@@ -1133,7 +1125,7 @@ Guacamole.StaticHTTPTunnel = function StaticHTTPTunnel(url, crossDomain) {
         tunnel.disconnect();
 
         // Connection is now starting
-        setState(Guacamole.Tunnel.State.CONNECTING);
+        tunnel.setState(Guacamole.Tunnel.State.CONNECTING);
 
         // Start a new connection
         xhr = new XMLHttpRequest();
@@ -1160,7 +1152,7 @@ Guacamole.StaticHTTPTunnel = function StaticHTTPTunnel(url, crossDomain) {
             if (xhr.readyState === 3 || xhr.readyState === 4) {
 
                 // Connection is open
-                setState(Guacamole.Tunnel.State.OPEN);
+                tunnel.setState(Guacamole.Tunnel.State.OPEN);
 
                 var buffer = xhr.responseText;
                 var length = buffer.length;
@@ -1200,7 +1192,7 @@ Guacamole.StaticHTTPTunnel = function StaticHTTPTunnel(url, crossDomain) {
         }
 
         // Connection is now closed
-        setState(Guacamole.Tunnel.State.CLOSED);
+        tunnel.setState(Guacamole.Tunnel.State.CLOSED);
 
     };
 

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -564,6 +564,9 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain) {
         // Start waiting for connect
         reset_timeout();
 
+        // Mark the tunnel as connecting
+        tunnel.setState(Guacamole.Tunnel.State.CONNECTING);
+
         // Start tunnel and connect
         var connect_xmlhttprequest = new XMLHttpRequest();
         connect_xmlhttprequest.onreadystatechange = function() {
@@ -759,6 +762,9 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
     this.connect = function(data) {
 
         reset_timeout();
+
+        // Mark the tunnel as connecting
+        tunnel.setState(Guacamole.Tunnel.State.CONNECTING);
 
         // Connect socket
         socket = new WebSocket(tunnelURL + "?" + data, "guacamole");


### PR DESCRIPTION
When the tunnel is closed and another `connect()` call is made, it stops
notifying about state changes (`onstatechanges`) if the connection continues
to fail.

Another issue is that the `Tunnel.onerror()` handler is never called the
second time, since it thinks the tunnel is already closed.

The fix is to set the state to `CONNECTING` when calling `connect()`.
I also moved the `setState()` function to the base Tunnel class and used
that whenever a state needs to change in any tunnel implementation, as this
seemed appropriate.